### PR TITLE
시맨틱 모델 생성 로직을 일반화한다

### DIFF
--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -63,7 +63,7 @@ class ResumePrinter
       )
 
       work_exps = []
-      @preproc.split_by_company(sections[:work_experience]).each do |work_exp|
+      @preproc.segments_by_keyword(sections[:work_experience]).each do |work_exp|
         work_exps << @preproc.group_by_company(work_exp.join("\n"))
       end
 
@@ -124,7 +124,7 @@ class ResumePrinter
       )
 
       side_projs = []
-      @preproc.split_by_company(sections[:side_project]).each do |side_proj|
+      @preproc.segments_by_keyword(sections[:side_project]).each do |side_proj|
         side_projs << @preproc.group_by_company(side_proj.join("\n"))
       end
 

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -64,7 +64,7 @@ class ResumePrinter
 
       work_exps = []
       @preproc.segments_by_keyword(sections[:work_experience]).each do |work_exp|
-        work_exps << @preproc.group_by_company(work_exp.join("\n"))
+        work_exps << @preproc.make_obj(work_exp.join("\n"))
       end
 
       work_exps.each do |work_exp|
@@ -125,7 +125,7 @@ class ResumePrinter
 
       side_projs = []
       @preproc.segments_by_keyword(sections[:side_project]).each do |side_proj|
-        side_projs << @preproc.group_by_company(side_proj.join("\n"))
+        side_projs << @preproc.make_obj(side_proj.join("\n"))
       end
 
       side_projs.each do |side_proj|

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -38,7 +38,7 @@ module MkResume
       end
     end
 
-    def group_by_company(obj_in_txt, kw_list = [:company_nm, :skill_set])
+    def make_obj(obj_in_txt, kw_list = [:company_nm, :skill_set])
       lines = obj_in_txt.split("\n")
 
       matching_lines = lines.filter {|l|

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -50,10 +50,10 @@ module MkResume
       obj
     end
 
-    def make_proj_obj plain_text_project
-      lines = plain_text_project.split("\n")
+    def make_proj_obj proj_in_txt
+      lines = proj_in_txt.split("\n")
 
-      project = {}
+      proj = {}
       nm = nil
       task_desc = nil
       lines.each do |l|
@@ -61,18 +61,18 @@ module MkResume
         when project?(l) then
           nmish = l.split(":")
           nm = nmish.size == 2 ? nmish[1].strip : l.split(":")[1..-1].join(":").strip
-          project[nm] = []
+          proj[nm] = []
         when task?(l) then
           task_desc = l.split(":").size > 1 ? l.split(":")[1].strip : :EMPTY_TASK_DESC
-          project[nm] << {task_desc => []}
+          proj[nm] << {task_desc => []}
         when details?(l) then
           ""
         else
-          idx = project[nm].find_index {|e| e[task_desc] != nil}
-          project[nm][idx][task_desc] << l.strip
+          idx = proj[nm].find_index {|e| e[task_desc] != nil}
+          proj[nm][idx][task_desc] << l.strip
         end
       end
-      project
+      proj
     end
   end
 end

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -1,19 +1,10 @@
 module MkResume
   class Preproc
-    def company_nm?(l)
-      l =~ /^\s*(company_nm:)/
-    end
-    def skill_set?(l)
-      l =~ /^\s*(skill_set:)/
-    end
     def task?(l)
       l =~ /^\s*(task:)/
     end
     def project?(l)
       l =~ /^\s*(project:)/
-    end
-    def what?(l)
-      l =~ /^\s*(what:)/
     end
     def details?(l)
       l =~ /^\s*(details:)/

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -19,20 +19,21 @@ module MkResume
       l =~ /^\s*(details:)/
     end
 
-    def split_by_company work_exp, obj_sep = "company_nm"
-      lines = work_exp.split("\n")
+    def segments_by_keyword objs_in_txt, obj_sep = "company_nm"
+      lines = objs_in_txt.split("\n")
 
-      ranges = []
+      obj_start_idxs = []
       lines.select {|l| l =~ /^\s*(#{obj_sep}:)/}.each do |l|
-        ranges << lines.find_index(l)
+        obj_start_idxs << lines.find_index(l)
       end
-      res = []
-      ranges.each.with_index do |range, idx|
-        if (idx == ranges.length - 1)
-          res << lines[range..(lines.length - 1)]
-          return res
+      obj_segments = []
+      obj_start_idxs.each.with_index do |obj_stt_idx, idx|
+        if (idx == obj_start_idxs.length - 1)
+          obj_segments << lines[obj_stt_idx..(lines.length - 1)]
+          return obj_segments
         else
-          res << lines[range...ranges[idx + 1]].delete_if {|l| l == ""}
+          obj_segments << lines[obj_stt_idx...obj_start_idxs[idx + 1]]
+                            .delete_if {|l| l == ""}
         end
       end
     end

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -38,22 +38,23 @@ module MkResume
       end
     end
 
-    def group_by_company(obj_in_txt)
+    def group_by_company(obj_in_txt, kw_list = [:company_nm, :skill_set])
       lines = obj_in_txt.split("\n")
 
+      matching_lines = lines.filter {|l|
+        kw_list.any? {|kw|
+          l =~ /^\s*(#{kw.to_s})/
+        }
+      }
+
       obj = {}
-      proj_in_txt = []
-      lines.each do |l|
-        case
-        when company_nm?(l) then
-          obj = {}
-          obj[:company_nm] = l.split(":")[1].strip
-        when skill_set?(l) then
-          obj[:skill_set] = l.split(":")[1].strip
-        else
-          proj_in_txt << l
-        end
-      end
+      matching_lines.each {|l|
+        k_v = l.split(":").map(&:strip)
+        obj[k_v[0].to_sym] = k_v[1]
+      }
+
+      proj_in_txt = lines - matching_lines
+
       obj[:project] = group_project proj_in_txt.join("\n") if proj_in_txt != []
       obj
     end

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -32,7 +32,7 @@ module MkResume
           res << lines[range..(lines.length - 1)]
           return res
         else
-          res << lines[range...ranges[idx + 1]]
+          res << lines[range...ranges[idx + 1]].delete_if {|l| l == ""}
         end
       end
     end

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -38,24 +38,24 @@ module MkResume
       end
     end
 
-    def group_by_company(work_exp)
-      lines = work_exp.split("\n")
+    def group_by_company(obj_in_txt)
+      lines = obj_in_txt.split("\n")
 
-      group = {}
-      plain_text_project = []
+      obj = {}
+      proj_in_txt = []
       lines.each do |l|
         case
         when company_nm?(l) then
-          group = {}
-          group[:company_nm] = l.split(":")[1].strip
+          obj = {}
+          obj[:company_nm] = l.split(":")[1].strip
         when skill_set?(l) then
-          group[:skill_set] = l.split(":")[1].strip
+          obj[:skill_set] = l.split(":")[1].strip
         else
-          plain_text_project << l
+          proj_in_txt << l
         end
       end
-      group[:project] = group_project plain_text_project.join("\n") if plain_text_project != []
-      group
+      obj[:project] = group_project proj_in_txt.join("\n") if proj_in_txt != []
+      obj
     end
 
     def group_project plain_text_project

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -19,11 +19,11 @@ module MkResume
       l =~ /^\s*(details:)/
     end
 
-    def split_by_company work_exp
+    def split_by_company work_exp, obj_sep = "company_nm"
       lines = work_exp.split("\n")
 
       ranges = []
-      lines.select {|l| company_nm?(l)}.each do |l|
+      lines.select {|l| l =~ /^\s*(#{obj_sep}:)/}.each do |l|
         ranges << lines.find_index(l)
       end
       res = []

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -46,11 +46,11 @@ module MkResume
 
       proj_in_txt = lines - matching_lines
 
-      obj[:project] = group_project proj_in_txt.join("\n") if proj_in_txt != []
+      obj[:project] = make_proj_obj proj_in_txt.join("\n") if proj_in_txt != []
       obj
     end
 
-    def group_project plain_text_project
+    def make_proj_obj plain_text_project
       lines = plain_text_project.split("\n")
 
       project = {}

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -59,8 +59,7 @@ module MkResume
       lines.each do |l|
         case
         when project?(l) then
-          nmish = l.split(":")
-          nm = nmish.size == 2 ? nmish[1].strip : l.split(":")[1..-1].join(":").strip
+          nm = l.split(":", 2)[1].strip
           proj[nm] = []
         when task?(l) then
           task_desc = l.split(":").size > 1 ? l.split(":")[1].strip : :EMPTY_TASK_DESC

--- a/spec/data/two_side_proj_nm
+++ b/spec/data/two_side_proj_nm
@@ -1,0 +1,3 @@
+side_proj_nm: s1
+
+side_proj_nm: s2

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -21,7 +21,7 @@ describe MkResume::Preproc do
         ["company_nm: c2"]
       ]
 
-      expect(@pp.split_by_company(File.read(src_path_sp))).to eq(expected)
+      expect(@pp.segments_by_keyword(File.read(src_path_sp))).to eq(expected)
     end
 
     it "키워드명이 project_nm일 때" do
@@ -32,7 +32,7 @@ describe MkResume::Preproc do
         ["side_proj_nm: s2"]
       ]
 
-      expect(@pp.split_by_company(File.read(src_path_sp), "side_proj_nm")).to eq(expected)
+      expect(@pp.segments_by_keyword(File.read(src_path_sp), "side_proj_nm")).to eq(expected)
     end
   end
 

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -24,7 +24,7 @@ describe MkResume::Preproc do
       expect(@pp.segments_by_keyword(File.read(src_path_sp))).to eq(expected)
     end
 
-    it "키워드명이 project_nm일 때" do
+    it "키워드명이 side_proj_nm일 때" do
       src_path_sp = File.join(TEST_DATA_DIR, *%w[two_side_proj_nm])
 
       expected = [

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -46,7 +46,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@pp.group_project(File.read(src_path_sp))).to eq(expected)
+      expect(@pp.make_proj_obj(File.read(src_path_sp))).to eq(expected)
     end
 
     it "업무 둘에 대한 상세 내용" do
@@ -59,7 +59,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@pp.group_project(File.read(src_path_sp))).to eq(expected)
+      expect(@pp.make_proj_obj(File.read(src_path_sp))).to eq(expected)
     end
 
     it "두 프로젝트, 프로젝트별 업무가 하나" do
@@ -74,7 +74,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@pp.group_project(File.read(src_path_sp))).to eq(expected)
+      expect(@pp.make_proj_obj(File.read(src_path_sp))).to eq(expected)
     end
 
     it "두 프로젝트, 프로젝트당 업무가 여러 개" do
@@ -91,7 +91,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@pp.group_project(File.read(src_path_sp))).to eq(expected)
+      expect(@pp.make_proj_obj(File.read(src_path_sp))).to eq(expected)
     end
   end
 

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -127,7 +127,7 @@ describe MkResume::Preproc do
         :company_nm => "c1"
       }
 
-      expect(@pp.group_by_company(File.read(src_path_sp))).to eq(expected)
+      expect(@pp.make_obj(File.read(src_path_sp))).to eq(expected)
     end
 
     it "회사 하나에 대한 포트폴리오" do
@@ -143,7 +143,7 @@ describe MkResume::Preproc do
         }
       }
 
-      expect(@pp.group_by_company(File.read(src_path_sp))).to eq(expected)
+      expect(@pp.make_obj(File.read(src_path_sp))).to eq(expected)
     end
 
     it "task_desc가 없는 경우 기본값을 설정한다" do
@@ -157,7 +157,7 @@ describe MkResume::Preproc do
         }
       }
 
-      expect(@pp.group_by_company(File.read(src_path_sp))).to eq(expected)
+      expect(@pp.make_obj(File.read(src_path_sp))).to eq(expected)
     end
 
     it "실제 데이터로 테스트한다" do
@@ -194,7 +194,7 @@ describe MkResume::Preproc do
         }
       }
 
-      expect(@pp.group_by_company(File.read(src_path_sp))).to eq(expected)
+      expect(@pp.make_obj(File.read(src_path_sp))).to eq(expected)
     end
   end
 end

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -17,7 +17,7 @@ describe MkResume::Preproc do
       src_path_sp = File.join(TEST_DATA_DIR, *%w[two_company_nm])
 
       expected = [
-        ["company_nm: c1", ""],
+        ["company_nm: c1"],
         ["company_nm: c2"]
       ]
 

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -96,6 +96,30 @@ describe MkResume::Preproc do
   end
 
   context "프로젝트 관련 정보와 회사 관련 정보를 함께 그룹핑할 수 있다" do
+
+    it "시맨틱 모델에 넣을 키워드를 메서드 인자로 쓸 수 있다" do
+      kw_list = [:company_nm, :skill_set]
+      lines = ["company_nm: xx", "nothing: yy", "skill_set: zz"]
+      obj = {}
+      # 주어진 키워드로 시작하는 줄만 필터링한다
+      matching_lines = lines.filter {|l|
+        kw_list.any? {|kw|
+          l =~ /^\s*(#{kw.to_s})/
+        }
+      }
+      expect(matching_lines).to eq(["company_nm: xx", "skill_set: zz"])
+
+      # 필터링한 줄을 객체에 저장한다
+      matching_lines.each {|l|
+        k_v = l.split(":").map(&:strip)
+        obj[k_v[0].to_sym] = k_v[1]
+      }
+      expect(obj).to eq({:company_nm => "xx", :skill_set => "zz"})
+
+      # 나머지 줄을 따로 모은다
+      expect(lines - matching_lines).to eq(["nothing: yy"])
+    end
+
     it "회사명 하나" do
       src_path_sp = File.join(TEST_DATA_DIR, *%w[one_company_nm])
 

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -12,8 +12,8 @@ describe MkResume::Preproc do
     @pp = MkResume::Preproc.new
   end
 
-  context "company_nm을 기준으로 도메인 객체 하나로 파싱할 영역을 나눌 수 있다" do
-    it "여러 회사명" do
+  context "키워드를 기준으로 시맨틱 모델 하나를 만들 영역을 나눌 수 있다" do
+    it "키워드명이 company_nm일 때" do
       src_path_sp = File.join(TEST_DATA_DIR, *%w[two_company_nm])
 
       expected = [
@@ -22,6 +22,17 @@ describe MkResume::Preproc do
       ]
 
       expect(@pp.split_by_company(File.read(src_path_sp))).to eq(expected)
+    end
+
+    it "키워드명이 project_nm일 때" do
+      src_path_sp = File.join(TEST_DATA_DIR, *%w[two_side_proj_nm])
+
+      expected = [
+        ["side_proj_nm: s1"],
+        ["side_proj_nm: s2"]
+      ]
+
+      expect(@pp.split_by_company(File.read(src_path_sp), "side_proj_nm")).to eq(expected)
     end
   end
 


### PR DESCRIPTION
- 작업 내용
  - preproc.rb에 정의한 메서드의 변수명, 구현 등이 work_experience 섹션을
    기준으로 되어 있다
  - 그렇다보니 preproc 내 로직을 써야 하는 다른 섹션을 추가해야 할 때 맥락을
    이해하기 힘들다
  - 더 범용적으로 쓸 수 있다는 걸 쉽게 알 수 있도록 메서드명 및 변수명을
    바꾸고, work_experience와 다른 구조를 갖는 섹션에 대한 시맨틱 모델을
    수월하게 만들 수 있도록 구현을 다듬는다

- 세부 작업 내용
  - 주어진 키워드를 기준으로 시맨틱 모델 하나를 만들 영역을 나눌 수 있다.
    기존에 쓰던 company_nm은 기본값으로 설정한다
  - split_by_company(), group_by_company() 메서드 역할 변화를 반영해 메서드명,
    변수명을 고친다
  - group_by_company()에서 사용할 키워드 목록을 인자로 받을 수 있다. 현재는
    프로젝트 관련 내용 위에 company_nm, skill_set 키워드가 와야 한다. 어떤
    키워드를 쓸지 메서드 호출부에서 정할 수 있도록 한다
  - group_by_company() -> make_obj()
  - group_project() -> make_proj_obj()
  - make_proj_obj() 변수명을 고친다

- 이외 코드 정리
  - 섹션 도메인 객체 생성 시 불필요한 빈 문자열은 제외한다
  - group_by_company() 메서드 구현을 파이프라인 방식으로 바꾼다
  - 쓰지 않는 메서드를 지운다
  - 테스트 설명 고친다
