### PR TITLE
포트폴리오 섹션을 파싱할 수 있도록 preproc 로직을 수정한다

### DIFF
--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -78,4 +78,52 @@ module MkResume
       l =~ /^\s*(details:)/
     end
   end
+
+  class PortfolioProjectMaker
+    def make proj_in_txt
+      lines = proj_in_txt.split("\n")
+
+      proj = {}
+      trouble_shoot_now = nil
+      lines.each do |l|
+        case
+        when project?(l) then
+          proj[:project] = {}
+        when tasks?(l) then
+          proj[:project][:tasks] = []
+          tasks_idx = lines.find_index { |l| tasks?(l) }
+          trb_sht_idx = lines.find_index { |l| trouble_shooting?(l) }
+          lines[tasks_idx + 1 .. trb_sht_idx - 1].each {|task|
+            proj[:project][:tasks] << task.strip!
+          }
+        when trouble_shooting?(l) then
+          x = proj[:project]
+          x[:trouble_shooting] = [] if x[:trouble_shooting] == nil
+          trouble_shoot_now = l.split(":", 2)[1].strip!
+          x[:trouble_shooting] << {trouble_shoot_now => []}
+        when details?(l) then
+          ""
+        else
+          if trouble_shoot_now != nil
+            idx = proj[:project][:trouble_shooting].find_index {|e| e[trouble_shoot_now] != nil}
+            proj[:project][:trouble_shooting][idx][trouble_shoot_now] << l.strip!
+          end
+        end
+      end
+      proj
+    end
+
+    def project?(l)
+      l =~ /^\s*(project:)/
+    end
+    def tasks?(l)
+      l =~ /^\s*(tasks:)/
+    end
+    def trouble_shooting?(l)
+      l =~ /^\s*(trouble_shooting:)/
+    end
+    def details?(l)
+      l =~ /^\s*(details:)/
+    end
+  end
 end

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -87,25 +87,23 @@ module MkResume
       trb_sht_now = nil
       lines.each do |l|
         case
-        when project?(l) then
-          proj[:project] = {}
         when tasks?(l) then
-          proj[:project][:tasks] = []
+          proj[:tasks] = []
           tasks_idx = lines.find_index { |l| tasks?(l) }
           trb_sht_idx = lines.find_index { |l| trouble_shooting?(l) }
           lines[tasks_idx + 1 .. trb_sht_idx - 1].each {|task|
-            proj[:project][:tasks] << task.strip!
+            proj[:tasks] << task.strip!
           }
         when trouble_shooting?(l) then
-          x = proj[:project]
+          x = proj
           x[:trouble_shooting] = [] if x[:trouble_shooting] == nil
           trb_sht_now = l.split(":", 2)[1].strip!
           x[:trouble_shooting] << {trb_sht_now => []}
         when details?(l) then
           trb_sht_detail_stt = lines.find_index { |l| details?(l) } + 1
           lines[trb_sht_detail_stt..-1].each {|detail|
-            idx = proj[:project][:trouble_shooting].find_index {|e| e[trb_sht_now] != nil}
-            proj[:project][:trouble_shooting][idx][trb_sht_now] << detail.strip!
+            idx = proj[:trouble_shooting].find_index {|e| e[trb_sht_now] != nil}
+            proj[:trouble_shooting][idx][trb_sht_now] << detail.strip!
           }
         else
           ""
@@ -114,9 +112,6 @@ module MkResume
       proj
     end
 
-    def project?(l)
-      l =~ /^\s*(project:)/
-    end
     def tasks?(l)
       l =~ /^\s*(tasks:)/
     end

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -84,7 +84,7 @@ module MkResume
       lines = proj_in_txt.split("\n")
 
       proj = {}
-      trouble_shoot_now = nil
+      trb_sht_now = nil
       lines.each do |l|
         case
         when project?(l) then
@@ -99,15 +99,16 @@ module MkResume
         when trouble_shooting?(l) then
           x = proj[:project]
           x[:trouble_shooting] = [] if x[:trouble_shooting] == nil
-          trouble_shoot_now = l.split(":", 2)[1].strip!
-          x[:trouble_shooting] << {trouble_shoot_now => []}
+          trb_sht_now = l.split(":", 2)[1].strip!
+          x[:trouble_shooting] << {trb_sht_now => []}
         when details?(l) then
-          ""
+          trb_sht_detail_stt = lines.find_index { |l| details?(l) } + 1
+          lines[trb_sht_detail_stt..-1].each {|detail|
+            idx = proj[:project][:trouble_shooting].find_index {|e| e[trb_sht_now] != nil}
+            proj[:project][:trouble_shooting][idx][trb_sht_now] << detail.strip!
+          }
         else
-          if trouble_shoot_now != nil
-            idx = proj[:project][:trouble_shooting].find_index {|e| e[trouble_shoot_now] != nil}
-            proj[:project][:trouble_shooting][idx][trouble_shoot_now] << l.strip!
-          end
+          ""
         end
       end
       proj

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -19,7 +19,7 @@ module MkResume
       end
     end
 
-    def make_obj(obj_in_txt, kw_list = [:company_nm, :skill_set], proj_klass = MkResume::BasicProject)
+    def make_obj(obj_in_txt, kw_list = [:company_nm, :skill_set], proj_maker_klass = MkResume::BasicProjectMaker)
       lines = obj_in_txt.split("\n")
 
       matching_lines = lines.filter {|l|
@@ -36,15 +36,15 @@ module MkResume
 
       proj_in_txt = lines - matching_lines
 
-      proj_maker = proj_klass.new
-      method = proj_maker.method(:make_proj_obj)
-      obj[:project] = method.call(proj_in_txt.join("\n")) if proj_in_txt != []
+      proj_obj_maker = proj_maker_klass.new
+      obj[:project] = proj_obj_maker.method(:make)
+                                    .call(proj_in_txt.join("\n")) if proj_in_txt != []
       obj
     end
   end
 
-  class BasicProject
-    def make_proj_obj proj_in_txt
+  class BasicProjectMaker
+    def make proj_in_txt
       lines = proj_in_txt.split("\n")
 
       proj = {}

--- a/lib/mk_resume/preproc.rb
+++ b/lib/mk_resume/preproc.rb
@@ -1,15 +1,5 @@
 module MkResume
   class Preproc
-    def task?(l)
-      l =~ /^\s*(task:)/
-    end
-    def project?(l)
-      l =~ /^\s*(project:)/
-    end
-    def details?(l)
-      l =~ /^\s*(details:)/
-    end
-
     def segments_by_keyword objs_in_txt, obj_sep = "company_nm"
       lines = objs_in_txt.split("\n")
 
@@ -29,7 +19,7 @@ module MkResume
       end
     end
 
-    def make_obj(obj_in_txt, kw_list = [:company_nm, :skill_set])
+    def make_obj(obj_in_txt, kw_list = [:company_nm, :skill_set], proj_klass = MkResume::BasicProject)
       lines = obj_in_txt.split("\n")
 
       matching_lines = lines.filter {|l|
@@ -46,10 +36,14 @@ module MkResume
 
       proj_in_txt = lines - matching_lines
 
-      obj[:project] = make_proj_obj proj_in_txt.join("\n") if proj_in_txt != []
+      proj_maker = proj_klass.new
+      method = proj_maker.method(:make_proj_obj)
+      obj[:project] = method.call(proj_in_txt.join("\n")) if proj_in_txt != []
       obj
     end
+  end
 
+  class BasicProject
     def make_proj_obj proj_in_txt
       lines = proj_in_txt.split("\n")
 
@@ -72,6 +66,16 @@ module MkResume
         end
       end
       proj
+    end
+
+    def task?(l)
+      l =~ /^\s*(task:)/
+    end
+    def project?(l)
+      l =~ /^\s*(project:)/
+    end
+    def details?(l)
+      l =~ /^\s*(details:)/
     end
   end
 end

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -10,7 +10,7 @@ describe MkResume::Preproc do
 
   before(:each) do
     @pp = MkResume::Preproc.new
-    @basic_proj = MkResume::BasicProject.new
+    @basic_proj = MkResume::BasicProjectMaker.new
   end
 
   context "키워드를 기준으로 시맨틱 모델 하나를 만들 영역을 나눌 수 있다" do
@@ -47,7 +47,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@basic_proj.make_proj_obj(File.read(src_path_sp))).to eq(expected)
+      expect(@basic_proj.make(File.read(src_path_sp))).to eq(expected)
     end
 
     it "업무 둘에 대한 상세 내용" do
@@ -60,7 +60,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@basic_proj.make_proj_obj(File.read(src_path_sp))).to eq(expected)
+      expect(@basic_proj.make(File.read(src_path_sp))).to eq(expected)
     end
 
     it "두 프로젝트, 프로젝트별 업무가 하나" do
@@ -75,7 +75,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@basic_proj.make_proj_obj(File.read(src_path_sp))).to eq(expected)
+      expect(@basic_proj.make(File.read(src_path_sp))).to eq(expected)
     end
 
     it "두 프로젝트, 프로젝트당 업무가 여러 개" do
@@ -92,7 +92,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@basic_proj.make_proj_obj(File.read(src_path_sp))).to eq(expected)
+      expect(@basic_proj.make(File.read(src_path_sp))).to eq(expected)
     end
   end
 

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -100,12 +100,10 @@ describe MkResume::Preproc do
       src_path_sp = File.join(TEST_DATA_DIR, *%w[portfolio_proj])
 
       expected = {
-        :project => {
-          :tasks => ["x", "y"],
-          :trouble_shooting => [
-            {"z" => ["z1" ,"z2" ,"z3"]}
-          ]
-        }
+        :tasks => ["x", "y"],
+        :trouble_shooting => [
+          {"z" => ["z1" ,"z2" ,"z3"]}
+        ]
       }
 
       expect(@portfolio_proj.make(File.read(src_path_sp))).to eq(expected)

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -11,6 +11,7 @@ describe MkResume::Preproc do
   before(:each) do
     @pp = MkResume::Preproc.new
     @basic_proj = MkResume::BasicProjectMaker.new
+    @portfolio_proj = MkResume::PortfolioProjectMaker.new
   end
 
   context "키워드를 기준으로 시맨틱 모델 하나를 만들 영역을 나눌 수 있다" do
@@ -93,6 +94,21 @@ describe MkResume::Preproc do
       }
 
       expect(@basic_proj.make(File.read(src_path_sp))).to eq(expected)
+    end
+
+    it "포트폴리오용 프로젝트 시맨틱 모델을 만들 수 있다" do
+      src_path_sp = File.join(TEST_DATA_DIR, *%w[portfolio_proj])
+
+      expected = {
+        :project => {
+          :tasks => ["x", "y"],
+          :trouble_shooting => [
+            {"z" => ["z1" ,"z2" ,"z3"]}
+          ]
+        }
+      }
+
+      expect(@portfolio_proj.make(File.read(src_path_sp))).to eq(expected)
     end
   end
 

--- a/spec/mk_resume/preproc_spec.rb
+++ b/spec/mk_resume/preproc_spec.rb
@@ -10,6 +10,7 @@ describe MkResume::Preproc do
 
   before(:each) do
     @pp = MkResume::Preproc.new
+    @basic_proj = MkResume::BasicProject.new
   end
 
   context "키워드를 기준으로 시맨틱 모델 하나를 만들 영역을 나눌 수 있다" do
@@ -46,7 +47,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@pp.make_proj_obj(File.read(src_path_sp))).to eq(expected)
+      expect(@basic_proj.make_proj_obj(File.read(src_path_sp))).to eq(expected)
     end
 
     it "업무 둘에 대한 상세 내용" do
@@ -59,7 +60,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@pp.make_proj_obj(File.read(src_path_sp))).to eq(expected)
+      expect(@basic_proj.make_proj_obj(File.read(src_path_sp))).to eq(expected)
     end
 
     it "두 프로젝트, 프로젝트별 업무가 하나" do
@@ -74,7 +75,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@pp.make_proj_obj(File.read(src_path_sp))).to eq(expected)
+      expect(@basic_proj.make_proj_obj(File.read(src_path_sp))).to eq(expected)
     end
 
     it "두 프로젝트, 프로젝트당 업무가 여러 개" do
@@ -91,7 +92,7 @@ describe MkResume::Preproc do
         ]
       }
 
-      expect(@pp.make_proj_obj(File.read(src_path_sp))).to eq(expected)
+      expect(@basic_proj.make_proj_obj(File.read(src_path_sp))).to eq(expected)
     end
   end
 


### PR DESCRIPTION
* 포트폴리오용 프로젝트 시맨틱 모델 생성 로직을 구현한다
  - 기존의 프로젝트 시맨틱 모델 생성 로직에서 포트폴리오용 프로젝트
    시맨틱 모델도 생성할 수 있게 만들면 기존 로직이 너무 복잡해질 것 같다
  - 대신 포트폴리오에서 쓸 프로젝트 시맨틱 모델을 생성하는 로직을 따로
    만들어 넣을 수 있도록 하기 위해, make() 인터페이스를 갖는
    객체를 make_obj의 proj_maker_klass 인자로 제공해서 쓸 수 있도록 바꾼다
  - 프로젝트 시맨틱 모델을 만들 수 있는 PortfolioProjectMaker 클래스를
     구현하고, make_obj에서 쓸 수 있도록 만든다