### PR TITLE
프로그램 내 요소 이름을 다듬는다

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### 구현한 것
 - 이력서를 구성하는 각 섹션을 [텍스트 파일](spec/data/src/)로부터 읽어와 [PDF](output.pdf)로 변환하는 [프로그램](lib/mk_pdf.rb)을 구현
-- 중첩 구조 등 복잡한 로직이 필요한 섹션의 경우, [파서](lib/mk_resume/preproc.rb) 구현
+- 중첩 구조 등 복잡한 로직이 필요한 섹션의 경우, [파서](lib/mk_resume/section_parser.rb) 구현
 
 ### 프로그램으로 개선한 것
 - 이력서 레이아웃 조정에 드는 시간이 감소

--- a/Rakefile
+++ b/Rakefile
@@ -2,17 +2,17 @@ require_relative './lib/mk_resume'
 
 desc "실제로 쓸 이력서를 만든다. 현재 최상위 디렉토리 바깥 src 디렉토리의 이력서 플레인 텍스트를 소스로 쓴다"
 task :prod do
-  ResumePrinter.new.run %W[.. .. .. src]
+  ResumePrinter.new.print %W[.. .. .. src]
 end
 
 desc "샘플용 이력서를 만든다. 현재 최상위 디렉토리 하위의 src 디렉토리에 이력서 플레인 텍스트를 소스로 쓴다"
 task :sample do
-  ResumePrinter.new.run %W[.. .. spec data src]
+  ResumePrinter.new.print %W[.. .. spec data src]
 end
 
 desc "생성 결과가 달라지지 않았는지 확인한다"
 task :test do
-  ResumePrinter.new.run %W[.. .. spec data src]
+  ResumePrinter.new.print %W[.. .. spec data src]
   x = `git diff --no-index ./output.pdf spec/data/sample.pdf`
   if x.strip != ""
     puts 'generated pdf is different from base pdf!'

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -17,7 +17,7 @@ class ResumePrinter
     @parser = MkResume::SectionParser.new
   end
 
-  def run(relative_path)
+  def print(relative_path)
 
     sections = @doc_writer.read_sections(relative_path)
 

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -1,6 +1,6 @@
 require 'prawn'
 require 'prawn/measurement_extensions'
-require_relative 'mk_resume/preproc'
+require_relative 'mk_resume/section_parser'
 require_relative 'mk_resume/font_manager'
 require_relative 'mk_resume/document_writer'
 require_relative 'mk_resume/layout_arranger'
@@ -14,7 +14,7 @@ class ResumePrinter
     @font_manager = MkResume::FontManager.new
     @formatting_config = MkResume::FormattingConfig.new
     @doc_writer = MkResume::DocumentWriter.new
-    @preproc = MkResume::Preproc.new
+    @parser = MkResume::SectionParser.new
   end
 
   def run(relative_path)
@@ -64,8 +64,8 @@ class ResumePrinter
       )
 
       portfolios = []
-      @preproc.segments_by_keyword(sections[:portfolio], "portfolio_nm").each do |portfolio|
-        portfolios << @preproc.make_obj(portfolio.join("\n"),
+      @parser.segments_by_keyword(sections[:portfolio], "portfolio_nm").each do |portfolio|
+        portfolios << @parser.make_obj(portfolio.join("\n"),
           [:portfolio_nm, :desc, :repo_link, :service_link, :swagger_link, :tech_stack],
           MkResume::PortfolioProjectMaker)
       end
@@ -156,8 +156,8 @@ class ResumePrinter
       )
 
       work_exps = []
-      @preproc.segments_by_keyword(sections[:work_experience]).each do |work_exp|
-        work_exps << @preproc.make_obj(work_exp.join("\n"))
+      @parser.segments_by_keyword(sections[:work_experience]).each do |work_exp|
+        work_exps << @parser.make_obj(work_exp.join("\n"))
       end
 
       work_exps.each do |work_exp|
@@ -217,8 +217,8 @@ class ResumePrinter
       )
 
       side_projs = []
-      @preproc.segments_by_keyword(sections[:side_project], "side_proj_nm").each do |side_proj|
-        side_projs << @preproc.make_obj(side_proj.join("\n"), [:side_proj_nm, :proj_link, :proj_desc])
+      @parser.segments_by_keyword(sections[:side_project], "side_proj_nm").each do |side_proj|
+        side_projs << @parser.make_obj(side_proj.join("\n"), [:side_proj_nm, :proj_link, :proj_desc])
       end
 
       side_projs.each do |side_proj|

--- a/lib/mk_resume/section_parser.rb
+++ b/lib/mk_resume/section_parser.rb
@@ -1,5 +1,5 @@
 module MkResume
-  class Preproc
+  class SectionParser
     def segments_by_keyword objs_in_txt, obj_sep = "company_nm"
       lines = objs_in_txt.split("\n")
 

--- a/spec/mk_resume/section_parser_spec.rb
+++ b/spec/mk_resume/section_parser_spec.rb
@@ -1,6 +1,6 @@
-require_relative "../../lib/mk_resume/preproc"
+require_relative "../../lib/mk_resume/section_parser"
 
-describe MkResume::Preproc do
+describe MkResume::SectionParser do
   RSpec.configure do |config|
     config.filter_run_when_matching(focus: true)
     config.example_status_persistence_file_path = 'spec/pass_fail_history'
@@ -9,7 +9,7 @@ describe MkResume::Preproc do
   TEST_DATA_DIR = File.join(File.dirname(__FILE__), *%w[.. data])
 
   before(:each) do
-    @pp = MkResume::Preproc.new
+    @parser = MkResume::SectionParser.new
   end
 
   context "키워드를 기준으로 시맨틱 모델 하나를 만들 영역을 나눌 수 있다" do
@@ -21,7 +21,7 @@ describe MkResume::Preproc do
         ["company_nm: c2"]
       ]
 
-      expect(@pp.segments_by_keyword(File.read(src_path))).to eq(expected)
+      expect(@parser.segments_by_keyword(File.read(src_path))).to eq(expected)
     end
 
     it "키워드명이 side_proj_nm일 때" do
@@ -32,7 +32,7 @@ describe MkResume::Preproc do
         ["side_proj_nm: s2"]
       ]
 
-      expect(@pp.segments_by_keyword(File.read(src_path), "side_proj_nm")).to eq(expected)
+      expect(@parser.segments_by_keyword(File.read(src_path), "side_proj_nm")).to eq(expected)
     end
   end
 
@@ -157,7 +157,7 @@ describe MkResume::Preproc do
         :company_nm => "c1"
       }
 
-      expect(@pp.make_obj(File.read(src_path))).to eq(expected)
+      expect(@parser.make_obj(File.read(src_path))).to eq(expected)
     end
 
     it "한 회사에서의 경력 사항" do
@@ -173,7 +173,7 @@ describe MkResume::Preproc do
         }
       }
 
-      expect(@pp.make_obj(File.read(src_path))).to eq(expected)
+      expect(@parser.make_obj(File.read(src_path))).to eq(expected)
     end
 
     it "회사 경력 사항 중 업무명이 명시되지 않았을 경우를 처리" do
@@ -187,7 +187,7 @@ describe MkResume::Preproc do
         }
       }
 
-      expect(@pp.make_obj(File.read(src_path))).to eq(expected)
+      expect(@parser.make_obj(File.read(src_path))).to eq(expected)
     end
 
     it "실제 데이터로 테스트한다" do
@@ -224,7 +224,7 @@ describe MkResume::Preproc do
         }
       }
 
-      expect(@pp.make_obj(File.read(src_path))).to eq(expected)
+      expect(@parser.make_obj(File.read(src_path))).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
* preproc -> section_parser
  - 시맨틱 모델 생성의 책임을 갖는 클래스명을 바꾼다
  - 이 타입의 인스턴스 이름에도 변경 사항을 반영한다
* ResumePrinter#run() -> ResumePrinter#print()
  - pdf 문서 생성 메서드명을 바꾼다