### PR TITLE
주어진 섹션 플레인 텍스트의 형식에 맞춰서 조판할 수 있다

### DIFF
--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -52,7 +52,8 @@ class ResumePrinter
         :doc => doc,
         :formatting_config => @formatting_config,
         :font_manager => @font_manager,
-        :layout_arranger => @layout_arranger
+        :layout_arranger => @layout_arranger,
+        :parser => @parser
       }
       typesetter.handler(sections[:introduction]).call(
         sections[:introduction],
@@ -160,57 +161,10 @@ class ResumePrinter
         @formatting_config.work_experience(:heading, @font_manager)
       )
 
-      work_exps = []
-      @parser.segments_by_keyword(sections[:work_experience]).each do |work_exp|
-        work_exps << @parser.make_obj(work_exp.join("\n"))
-      end
-
-      work_exps.each do |work_exp|
-        @doc_writer.write_text(
-          doc,
-          work_exp[:company_nm],
-          @formatting_config.work_experience(:default, @font_manager)
-          .merge!({:line_spacing_pt => 2})
-        )
-        @doc_writer.write_text(
-          doc,
-          "사용기술: #{work_exp[:skill_set]}",
-          @formatting_config.work_experience(:long_leading, @font_manager)
-            .merge!({:line_spacing_pt => 2})
-        ) if work_exp[:skill_set]
-
-        work_exp[:project].keys.each do |task|
-          @doc_writer.write_text(
-            doc,
-            task,
-            @formatting_config.work_experience(:default, @font_manager)
-          )
-
-          work_exp[:project][task].each do |task_info|
-            task_info.each_key {|task_desc|
-              @doc_writer.write_indented_text(
-                doc,
-                "      ",
-                task_desc,
-                @formatting_config.work_experience(:default, @font_manager)
-              ) if task_desc != :EMPTY_TASK_DESC
-              task_details = task_info[task_desc]
-              task_details.each do |task_detail|
-                @doc_writer.write_indented_text(
-                  doc,
-                  "      ",
-                  "- #{task_detail}",
-                  @formatting_config.work_experience(:default, @font_manager)
-                    .merge!({:line_spacing_pt => 2})
-                )
-              end
-              @layout_arranger.v_space(doc, 2)
-              @layout_arranger.v_space(doc, 2)
-              @layout_arranger.v_space(doc, 2)
-            }
-          end
-        end
-      end
+      typesetter.handler(sections[:work_experience]).call(
+        sections[:work_experience],
+        typeset_opts
+      )
       @layout_arranger.v_space(doc, 2)
       @layout_arranger.v_space(doc, 14.5)
 

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -96,40 +96,10 @@ class ResumePrinter
         @formatting_config.side_project(:heading, @font_manager)
       )
 
-      side_projs = []
-      @parser.segments_by_keyword(sections[:side_project], "side_proj_nm").each do |side_proj|
-        side_projs << @parser.make_obj(side_proj.join("\n"), [:side_proj_nm, :proj_link, :proj_desc])
-      end
-
-      side_projs.each do |side_proj|
-
-        match = side_proj[:proj_link].match(/<link href='([^']*)'>([^<]*)<\/link>/)
-        link_url = match[1]
-        link_text = match[2]
-
-        @doc_writer.write_formatted_text(
-          doc,
-          [
-            { text: side_proj[:side_proj_nm], leading: 6 },
-            { text: " (" },
-            { text: "#{link_text}", leading: 6, styles: [:underline], color: "888888", link: link_url },
-            { text: ")" },
-          ],
-          @formatting_config.side_project(:project, @font_manager)
-        )
-
-        @layout_arranger.v_space(doc, 2)
-
-        @doc_writer.write_indented_text(
-          doc,
-          "      ",
-          side_proj[:proj_desc],
-          @formatting_config.side_project(:default, @font_manager)
-        )
-        @layout_arranger.v_space(doc, 2)
-        @layout_arranger.v_space(doc, 2)
-        @layout_arranger.v_space(doc, 2)
-      end
+      typesetter.handler(sections[:side_project]).call(
+        sections[:side_project],
+        typeset_opts
+      )
       @layout_arranger.v_space(doc, 2)
       @layout_arranger.v_space(doc, 14.5)
 

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -5,6 +5,7 @@ require_relative 'mk_resume/font_manager'
 require_relative 'mk_resume/document_writer'
 require_relative 'mk_resume/layout_arranger'
 require_relative 'mk_resume/formatting_config'
+require_relative 'mk_resume/pdf_typesetter'
 
 # 플레인 텍스트 형식으로 적은 이력서를 pdf로 변환하기 위한 스크립트
 
@@ -45,15 +46,18 @@ class ResumePrinter
         @formatting_config.introduction(:heading, @font_manager)
       )
 
-      sections[:introduction].split("\n").each do |text|
-        @doc_writer.write_indented_text(
-          doc,
-          "- ",
-          text,
-          @formatting_config.introduction(:default, @font_manager)
-            .merge!({:line_spacing_pt => 2})
-        )
-      end
+      typesetter = MkResume::PdfTypesetter.new
+      typeset_opts = {
+        :doc_writer => @doc_writer,
+        :doc => doc,
+        :formatting_config => @formatting_config,
+        :font_manager => @font_manager
+      }
+      typesetter.handler(sections[:introduction]).call(
+        sections[:introduction],
+        typeset_opts
+      )
+
       @layout_arranger.v_space(doc, 14.5)
 
 

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -20,8 +20,6 @@ class ResumePrinter
 
   def print(relative_path)
 
-    sections = @doc_writer.read_sections(relative_path)
-
     Prawn::Document.generate(
       "output.pdf",
       page_size: "A4",
@@ -40,35 +38,16 @@ class ResumePrinter
         :parser => @parser
       }
 
-      typesetter.handler(sections[:personal_info]).call(
-        sections[:personal_info],
-        typeset_opts
-      )
-
-      typesetter.handler(sections[:introduction]).call(
-        sections[:introduction],
-        typeset_opts
-      )
-
-      typesetter.handler(sections[:portfolio]).call(
-        sections[:portfolio],
-        typeset_opts
-      )
-
-      typesetter.handler(sections[:work_experience]).call(
-        sections[:work_experience],
-        typeset_opts
-      )
-
-      typesetter.handler(sections[:side_project]).call(
-        sections[:side_project],
-        typeset_opts
-      )
-
-      typesetter.handler(sections[:education]).call(
-        sections[:education],
-        typeset_opts
-      )
+      sections = @doc_writer.read_sections(relative_path)
+      [
+        :personal_info, :introduction, :portfolio,
+        :work_experience, :side_project, :education
+      ].each { |section_nm|
+        typesetter.handler(sections[section_nm]).call(
+          sections[section_nm],
+          typeset_opts
+        )
+      }
     end
   end
 end

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -30,22 +30,6 @@ class ResumePrinter
 
       @font_manager.load_font(doc)
 
-      sections[:personal_info].split("\n")[0..4].each.with_index do |text, idx|
-        @doc_writer.write_text(
-          doc,
-          text,
-          @formatting_config.personal_info(idx, @font_manager)
-        )
-      end
-      @layout_arranger.v_space(doc, 14.5)
-
-
-      @doc_writer.write_heading(
-        doc,
-        :introduction.to_s.capitalize,
-        @formatting_config.introduction(:heading, @font_manager)
-      )
-
       typesetter = MkResume::PdfTypesetter.new
       typeset_opts = {
         :doc_writer => @doc_writer,
@@ -55,6 +39,21 @@ class ResumePrinter
         :layout_arranger => @layout_arranger,
         :parser => @parser
       }
+
+      typesetter.handler(sections[:personal_info]).call(
+        sections[:personal_info],
+        typeset_opts
+      )
+
+      @layout_arranger.v_space(doc, 14.5)
+
+
+      @doc_writer.write_heading(
+        doc,
+        :introduction.to_s.capitalize,
+        @formatting_config.introduction(:heading, @font_manager)
+      )
+
       typesetter.handler(sections[:introduction]).call(
         sections[:introduction],
         typeset_opts

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -69,88 +69,10 @@ class ResumePrinter
         @formatting_config.portfolio(:heading, @font_manager)
       )
 
-      portfolios = []
-      @parser.segments_by_keyword(sections[:portfolio], "portfolio_nm").each do |portfolio|
-        portfolios << @parser.make_obj(portfolio.join("\n"),
-          [:portfolio_nm, :desc, :repo_link, :service_link, :swagger_link, :tech_stack],
-          MkResume::PortfolioProjectMaker)
-      end
-
-      portfolios.each do |portfolio|
-        match = portfolio[:repo_link].match(/<link href='([^']*)'>([^<]*)<\/link>/)
-        link_url = match[1]
-        link_text = match[2]
-
-        @doc_writer.write_formatted_text(
-          doc,
-          [
-            { text: portfolio[:portfolio_nm], leading: 6 },
-            { text: " (" },
-            { text: "#{link_text}", leading: 6, styles: [:underline], color: "888888", link: link_url },
-            { text: ")" },
-          ],
-          @formatting_config.portfolio(:project, @font_manager)
-        )
-        @layout_arranger.v_space(doc, 10)
-
-        @doc_writer.write_text(
-          doc,
-          portfolio[:desc],
-          @formatting_config.portfolio(:default, @font_manager)
-                            .merge!({:line_spacing_pt => 2})
-        )
-
-        @doc_writer.write_text(
-          doc,
-          "사용 기술: #{portfolio[:tech_stack]}",
-          @formatting_config.portfolio(:default, @font_manager)
-                            .merge!({:line_spacing_pt => 2})
-        )
-
-        @doc_writer.write_text(
-          doc,
-          "담당 작업",
-          @formatting_config.portfolio(:default, @font_manager)
-        )
-        portfolio[:project][:tasks].each do |task|
-          @doc_writer.write_indented_text(
-            doc,
-            "  ",
-            "- #{task}",
-            @formatting_config.portfolio(:default, @font_manager)
-              .merge!({:line_spacing_pt => 2})
-          )
-        end
-        @layout_arranger.v_space(doc, 2)
-
-        portfolio[:project][:trouble_shooting].each do |trb_sht_info|
-          trb_sht_info.each_key do |trb_sht_desc|
-            @doc_writer.write_text(
-              doc,
-              "해결한 문제: #{trb_sht_desc}",
-              @formatting_config.portfolio(:default, @font_manager)
-            )
-
-            trb_sht_info[trb_sht_desc].each do |trb_sht_detail|
-              @doc_writer.write_indented_text(
-                doc,
-                "  ",
-                "- #{trb_sht_detail}",
-                @formatting_config.portfolio(:default, @font_manager)
-                                  .merge!({:line_spacing_pt => 2})
-              )
-            end
-            @layout_arranger.v_space(doc, 2)
-            @layout_arranger.v_space(doc, 2)
-            @layout_arranger.v_space(doc, 2)
-
-          end
-        end
-
-        @layout_arranger.v_space(doc, 2)
-        @layout_arranger.v_space(doc, 2)
-        @layout_arranger.v_space(doc, 2)
-      end
+      typesetter.handler(sections[:portfolio]).call(
+        sections[:portfolio],
+        typeset_opts
+      )
       @layout_arranger.v_space(doc, 2)
       @layout_arranger.v_space(doc, 14.5)
 

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -45,68 +45,24 @@ class ResumePrinter
         typeset_opts
       )
 
-      @layout_arranger.v_space(doc, 14.5)
-
-
-      @doc_writer.write_heading(
-        doc,
-        :introduction.to_s.capitalize,
-        @formatting_config.introduction(:heading, @font_manager)
-      )
-
       typesetter.handler(sections[:introduction]).call(
         sections[:introduction],
         typeset_opts
-      )
-
-      @layout_arranger.v_space(doc, 14.5)
-
-
-      @doc_writer.write_heading(
-        doc,
-        :portfolio.to_s.capitalize,
-        @formatting_config.portfolio(:heading, @font_manager)
       )
 
       typesetter.handler(sections[:portfolio]).call(
         sections[:portfolio],
         typeset_opts
       )
-      @layout_arranger.v_space(doc, 2)
-      @layout_arranger.v_space(doc, 14.5)
-
-
-      @doc_writer.write_heading(
-        doc,
-        :work_experience.to_s.split("_").map(&:capitalize).join(" "),
-        @formatting_config.work_experience(:heading, @font_manager)
-      )
 
       typesetter.handler(sections[:work_experience]).call(
         sections[:work_experience],
         typeset_opts
       )
-      @layout_arranger.v_space(doc, 2)
-      @layout_arranger.v_space(doc, 14.5)
-
-
-      @doc_writer.write_heading(
-        doc,
-        :side_project.to_s.split("_").map(&:capitalize).join(" "),
-        @formatting_config.side_project(:heading, @font_manager)
-      )
 
       typesetter.handler(sections[:side_project]).call(
         sections[:side_project],
         typeset_opts
-      )
-      @layout_arranger.v_space(doc, 2)
-      @layout_arranger.v_space(doc, 14.5)
-
-      @doc_writer.write_heading(
-        doc,
-        :education.to_s.capitalize,
-        @formatting_config.education(:heading, @font_manager, doc)
       )
 
       typesetter.handler(sections[:education]).call(

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -51,7 +51,8 @@ class ResumePrinter
         :doc_writer => @doc_writer,
         :doc => doc,
         :formatting_config => @formatting_config,
-        :font_manager => @font_manager
+        :font_manager => @font_manager,
+        :layout_arranger => @layout_arranger
       }
       typesetter.handler(sections[:introduction]).call(
         sections[:introduction],
@@ -263,27 +264,10 @@ class ResumePrinter
         @formatting_config.education(:heading, @font_manager, doc)
       )
 
-      sections[:education].split("\n")
-        .map! { |cols|
-          cols.split("|")
-            .each { |col| col.strip! }
-        }.each do |left_text, right_text|
-          # Draw left column text
-          @doc_writer.write_text_box(
-            doc,
-            left_text,
-            @formatting_config.education(:left, @font_manager, doc)
-          )
-
-          # Draw right column text, positioned to start at the right_col_start
-          @doc_writer.write_text_box(
-            doc,
-            right_text,
-            @formatting_config.education(:right, @font_manager, doc)
-          )
-
-          @layout_arranger.v_space(doc, 15) # Space between rows; adjust as needed
-        end
+      typesetter.handler(sections[:education]).call(
+        sections[:education],
+        typeset_opts
+      )
     end
   end
 end

--- a/lib/mk_resume/document_writer.rb
+++ b/lib/mk_resume/document_writer.rb
@@ -7,9 +7,11 @@ module MkResume
     end
 
     def read_sections(relative_path)
-      [:personal_info, :introduction, :work_experience, :side_project, :education, :portfolio].each {|file_sym|
-        @sections.store(file_sym, read_file(file_sym.to_s, relative_path))
-      }
+      Dir.entries(File.join(File.dirname(__FILE__), *relative_path))
+         .reject {|entry| entry.match?(/^\..*$/)} # 반환값 중 필요 없는 ., .., .DS_Store 를 제외한다
+         .map {|entry| entry.to_sym}
+         .each {|file_sym| @sections.store(file_sym, read_file(file_sym.to_s, relative_path))}
+
       @sections
     end
 

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -58,6 +58,12 @@ module MkResume
 
     def handler
       lambda {|section_txt, opts|
+        opts[:doc_writer].write_heading(
+          opts[:doc],
+          :side_project.to_s.split("_").map(&:capitalize).join(" "),
+          opts[:formatting_config].side_project(:heading, opts[:font_manager])
+        )
+
         side_projs = []
         opts[:parser].segments_by_keyword(section_txt, "side_proj_nm").each do |side_proj|
           side_projs << opts[:parser].make_obj(side_proj.join("\n"), [:side_proj_nm, :proj_link, :proj_desc])
@@ -91,6 +97,9 @@ module MkResume
           opts[:layout_arranger].v_space(opts[:doc], 2)
           opts[:layout_arranger].v_space(opts[:doc], 2)
         end
+
+        opts[:layout_arranger].v_space(opts[:doc], 2)
+        opts[:layout_arranger].v_space(opts[:doc], 14.5)
       }
     end
   end
@@ -104,6 +113,12 @@ module MkResume
 
     def handler
       lambda {|section_txt, opts|
+        opts[:doc_writer].write_heading(
+          opts[:doc],
+          :work_experience.to_s.split("_").map(&:capitalize).join(" "),
+          opts[:formatting_config].work_experience(:heading, opts[:font_manager])
+        )
+
         work_exps = []
         opts[:parser].segments_by_keyword(section_txt).each do |work_exp|
           work_exps << opts[:parser].make_obj(work_exp.join("\n"))
@@ -155,6 +170,9 @@ module MkResume
             end
           end
         end
+
+        opts[:layout_arranger].v_space(opts[:doc], 2)
+        opts[:layout_arranger].v_space(opts[:doc], 14.5)
       }
     end
   end
@@ -168,6 +186,12 @@ module MkResume
 
     def handler
       lambda {|section_txt, opts|
+        opts[:doc_writer].write_heading(
+          opts[:doc],
+          :portfolio.to_s.capitalize,
+          opts[:formatting_config].portfolio(:heading, opts[:font_manager])
+        )
+
         portfolios = []
         opts[:parser].segments_by_keyword(section_txt, "portfolio_nm").each do |portfolio|
           portfolios << opts[:parser].make_obj(portfolio.join("\n"),
@@ -250,6 +274,9 @@ module MkResume
           opts[:layout_arranger].v_space(opts[:doc], 2)
           opts[:layout_arranger].v_space(opts[:doc], 2)
         end
+
+        opts[:layout_arranger].v_space(opts[:doc], 2)
+        opts[:layout_arranger].v_space(opts[:doc], 14.5)
       }
     end
   end
@@ -264,6 +291,12 @@ module MkResume
 
     def handler
       lambda {|section_txt, opts|
+        opts[:doc_writer].write_heading(
+          opts[:doc],
+          :introduction.to_s.capitalize,
+          opts[:formatting_config].introduction(:heading, opts[:font_manager])
+        )
+
         section_txt.split("\n").each do |txt|
           opts[:doc_writer].write_indented_text(
             opts[:doc],
@@ -273,6 +306,8 @@ module MkResume
                               .merge!({:line_spacing_pt => 2})
           )
         end
+
+        opts[:layout_arranger].v_space(opts[:doc], 14.5)
       }
     end
   end
@@ -287,6 +322,12 @@ module MkResume
 
     def handler
       lambda {|section_txt, opts|
+        opts[:doc_writer].write_heading(
+          opts[:doc],
+          :education.to_s.capitalize,
+          opts[:formatting_config].education(:heading, opts[:font_manager], opts[:doc])
+        )
+
         section_txt.split("\n")
                             .map! { |cols|
                               cols.split("|")
@@ -326,6 +367,7 @@ module MkResume
             opts[:formatting_config].personal_info(idx, opts[:font_manager])
           )
         end
+        opts[:layout_arranger].v_space(opts[:doc], 14.5)
       }
     end
   end

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -269,5 +269,17 @@ module MkResume
     def can_handle? section_txt
       true
     end
+
+    def handler
+      lambda {|section_txt, opts|
+        section_txt.split("\n")[0..4].each.with_index do |text, idx|
+          opts[:doc_writer].write_text(
+            opts[:doc],
+            text,
+            opts[:formatting_config].personal_info(idx, opts[:font_manager])
+          )
+        end
+      }
+    end
   end
 end

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -9,6 +9,12 @@ module MkResume
       ]
     end
 
+    def handler section_txt
+      strategy_nm = find_strategy(section_txt)
+      strategy = Object::const_get(strategy_nm).new
+      strategy.handler
+    end
+
     def find_strategy section_txt
       matching_strategy = self.strategy_list.reduce([]) {|result, strategy_nm|
         strategy = Object::const_get(strategy_nm).new
@@ -37,6 +43,10 @@ module MkResume
     def can_handle? section_txt
       raise "Not implemented"
     end
+
+    def handler
+      raise "Not implemented"
+    end
   end
 
   class WorkExpTypesetStrategy
@@ -61,6 +71,20 @@ module MkResume
     def can_handle? section_txt
       lines = section_txt.split("\n")
       lines.size == lines.filter {|l| l.match(/^\s*-\s+.*$/)}.size
+    end
+
+    def handler
+      lambda {|section_txt, opts|
+        section_txt.split("\n").each do |txt|
+          opts[:doc_writer].write_indented_text(
+            opts[:doc],
+            "- ",
+            txt,
+            opts[:formatting_config].introduction(:default, opts[:font_manager])
+                              .merge!({:line_spacing_pt => 2})
+          )
+        end
+      }
     end
   end
 

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -5,7 +5,8 @@ module MkResume
         WorkExpTypesetStrategy.name,
         PortfolioTypesetStrategy.name,
         ListTypesetStrategy.name,
-        TwoColumnsTypesetStrategy.name
+        TwoColumnsTypesetStrategy.name,
+        SideProjTypesetStrategy.name
       ]
     end
 
@@ -45,6 +46,14 @@ module MkResume
 
     def handler
       raise "Not implemented"
+    end
+  end
+
+  class SideProjTypesetStrategy
+    include TypesetStrategy
+
+    def can_handle? section_txt
+      section_txt.split("\n").first.match(/^side_proj_nm:.*$/)
     end
   end
 

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -95,6 +95,30 @@ module MkResume
       lines = section_txt.split("\n")
       lines.size == lines.filter { |l| l.match(/^.*\s*\|\s*.*$/) }.size
     end
+
+    def handler
+      lambda {|section_txt, opts|
+        section_txt.split("\n")
+                            .map! { |cols|
+                              cols.split("|")
+                                  .each { |col| col.strip! }
+                            }.each do |left_text, right_text|
+          opts[:doc_writer].write_text_box(
+            opts[:doc],
+            left_text,
+            opts[:formatting_config].education(:left, opts[:font_manager], opts[:doc])
+          )
+
+          opts[:doc_writer].write_text_box(
+            opts[:doc],
+            right_text,
+            opts[:formatting_config].education(:right, opts[:font_manager], opts[:doc])
+          )
+
+          opts[:layout_arranger].v_space(opts[:doc], 15)
+        end
+      }
+    end
   end
 
   class DefaultTypesetStrategy

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -22,18 +22,17 @@ module MkResume
         result
       }
 
-      validate_search_result matching_strategy
-
-      matching_strategy.first
+      validate_search_result(matching_strategy)
     end
 
     def validate_search_result matching_strategy
-      if matching_strategy.nil?
+      if matching_strategy.size == 0
         return DefaultTypesetStrategy.name
       end
       if matching_strategy.size > 1
         raise TypesetStrategyFindError.new("found more than one typeset strategy to handle given section text!")
       end
+      matching_strategy.first
     end
   end
 

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -55,6 +55,44 @@ module MkResume
     def can_handle? section_txt
       section_txt.split("\n").first.match(/^side_proj_nm:.*$/)
     end
+
+    def handler
+      lambda {|section_txt, opts|
+        side_projs = []
+        opts[:parser].segments_by_keyword(section_txt, "side_proj_nm").each do |side_proj|
+          side_projs << opts[:parser].make_obj(side_proj.join("\n"), [:side_proj_nm, :proj_link, :proj_desc])
+        end
+
+        side_projs.each do |side_proj|
+          match = side_proj[:proj_link].match(/<link href='([^']*)'>([^<]*)<\/link>/)
+          link_url = match[1]
+          link_text = match[2]
+
+          opts[:doc_writer].write_formatted_text(
+            opts[:doc],
+            [
+              { text: side_proj[:side_proj_nm], leading: 6 },
+              { text: " (" },
+              { text: "#{link_text}", leading: 6, styles: [:underline], color: "888888", link: link_url },
+              { text: ")" },
+            ],
+            opts[:formatting_config].side_project(:project, opts[:font_manager])
+          )
+
+          opts[:layout_arranger].v_space(opts[:doc], 2)
+
+          opts[:doc_writer].write_indented_text(
+            opts[:doc],
+            "      ",
+            side_proj[:proj_desc],
+            opts[:formatting_config].side_project(:default, opts[:font_manager])
+          )
+          opts[:layout_arranger].v_space(opts[:doc], 2)
+          opts[:layout_arranger].v_space(opts[:doc], 2)
+          opts[:layout_arranger].v_space(opts[:doc], 2)
+        end
+      }
+    end
   end
 
   class WorkExpTypesetStrategy

--- a/spec/mk_resume/pdf_typesetter_spec.rb
+++ b/spec/mk_resume/pdf_typesetter_spec.rb
@@ -65,5 +65,11 @@ describe MkResume::PdfTypesetter do
 
       expect(typesetter.handler(File.read(src_path)).lambda?).to eq(true)
     end
+
+    it "2열 형식 섹션" do
+      src_path = File.join(SECTION_DATA_DIR, *%w[education])
+
+      expect(typesetter.handler(File.read(src_path)).lambda?).to eq(true)
+    end
   end
 end

--- a/spec/mk_resume/pdf_typesetter_spec.rb
+++ b/spec/mk_resume/pdf_typesetter_spec.rb
@@ -46,7 +46,7 @@ describe MkResume::PdfTypesetter do
 
     it "일치하는 전략 객체가 없을 때" do
       expect(
-        typesetter.validate_search_result(nil)
+        typesetter.validate_search_result([])
       ).to eq(MkResume::DefaultTypesetStrategy.name)
     end
 

--- a/spec/mk_resume/pdf_typesetter_spec.rb
+++ b/spec/mk_resume/pdf_typesetter_spec.rb
@@ -56,4 +56,14 @@ describe MkResume::PdfTypesetter do
       }.to raise_error(MkResume::TypesetStrategyFindError)
     end
   end
+
+  context "주어진 섹션 플레인 텍스트를 조판할 수 있는 방법을 알 수 있다" do
+    typesetter = MkResume::PdfTypesetter.new
+
+    it "목록 형식 섹션" do
+      src_path = File.join(SECTION_DATA_DIR, *%w[introduction])
+
+      expect(typesetter.handler(File.read(src_path)).lambda?).to eq(true)
+    end
+  end
 end

--- a/spec/mk_resume/pdf_typesetter_spec.rb
+++ b/spec/mk_resume/pdf_typesetter_spec.rb
@@ -60,6 +60,12 @@ describe MkResume::PdfTypesetter do
   context "주어진 섹션 플레인 텍스트를 조판할 수 있는 방법을 알 수 있다" do
     typesetter = MkResume::PdfTypesetter.new
 
+    it "업무 경력 섹션" do
+      src_path = File.join(SECTION_DATA_DIR, *%w[work_experience])
+
+      expect(typesetter.handler(File.read(src_path)).lambda?).to eq(true)
+    end
+
     it "목록 형식 섹션" do
       src_path = File.join(SECTION_DATA_DIR, *%w[introduction])
 

--- a/spec/mk_resume/pdf_typesetter_spec.rb
+++ b/spec/mk_resume/pdf_typesetter_spec.rb
@@ -78,6 +78,12 @@ describe MkResume::PdfTypesetter do
       expect(typesetter.handler(File.read(src_path)).lambda?).to eq(true)
     end
 
+    it "사이드 프로젝트 섹션" do
+      src_path = File.join(SECTION_DATA_DIR, *%w[side_project])
+
+      expect(typesetter.handler(File.read(src_path)).lambda?).to eq(true)
+    end
+
     it "목록 형식 섹션" do
       src_path = File.join(SECTION_DATA_DIR, *%w[introduction])
 

--- a/spec/mk_resume/pdf_typesetter_spec.rb
+++ b/spec/mk_resume/pdf_typesetter_spec.rb
@@ -83,5 +83,11 @@ describe MkResume::PdfTypesetter do
 
       expect(typesetter.handler(File.read(src_path)).lambda?).to eq(true)
     end
+
+    it "일치하는 전략 객체가 없을 때" do
+      src_path = File.join(SECTION_DATA_DIR, *%w[personal_info])
+
+      expect(typesetter.handler(File.read(src_path)).lambda?).to eq(true)
+    end
   end
 end

--- a/spec/mk_resume/pdf_typesetter_spec.rb
+++ b/spec/mk_resume/pdf_typesetter_spec.rb
@@ -32,6 +32,12 @@ describe MkResume::PdfTypesetter do
       expect(typesetter.find_strategy(File.read(src_path))).to eq(MkResume::PortfolioTypesetStrategy.name)
     end
 
+    it "사이드 프로젝트 섹션" do
+      src_path = File.join(SECTION_DATA_DIR, *%w[side_project])
+
+      expect(typesetter.find_strategy(File.read(src_path))).to eq(MkResume::SideProjTypesetStrategy.name)
+    end
+
     it "목록 형식 섹션" do
       src_path = File.join(SECTION_DATA_DIR, *%w[list_section])
 

--- a/spec/mk_resume/pdf_typesetter_spec.rb
+++ b/spec/mk_resume/pdf_typesetter_spec.rb
@@ -66,6 +66,12 @@ describe MkResume::PdfTypesetter do
       expect(typesetter.handler(File.read(src_path)).lambda?).to eq(true)
     end
 
+    it "포트폴리오 섹션" do
+      src_path = File.join(SECTION_DATA_DIR, *%w[portfolio])
+
+      expect(typesetter.handler(File.read(src_path)).lambda?).to eq(true)
+    end
+
     it "목록 형식 섹션" do
       src_path = File.join(SECTION_DATA_DIR, *%w[introduction])
 


### PR DESCRIPTION
* ResumePrinter에 있던 각 섹션 조판의 책임을 PdfTypesetter로 옮긴다
  - PdfTypesetter는 각 섹션의 플레인 텍스트를 조판할 수 있는 방법을 알아낼 수 있다

* 조판 전략 검증 로직 오류를 고친다
  - PdfTypesetter#find_strategy()에서 reduce 문장이 반환하는 기본값은
    nil이 아니라 []다. 테스트에서 기본값을 nil로 잘못 정의하고 있어서 고쳤다
  - 테스트했을 때와는 다르게, PdfTypesetter#find_strategy()의
    실행흐름에서 PdfTypesetter#validate_search_result()가
    DefaultTypesetStrategy.name을 반환할 경우, 이 값이 호출 메서드로
    반환되지 않고 있었다. 반환할 값을 PdfTypesetter#validate_search_result()에서만 만들도록 해서 오류가 나지 않도록 고쳤다

* PdfTypesetter에서 사이드 프로젝트 섹션을 처리할 수 있게 한다
  - 다른 섹션과 마찬가지로 사이드 프로젝트 섹션을 조판할 수 있는 전략 객체 구현한다
  - 사이드 프로젝트 섹션 조판의 책임을 PdfTypesetter로 옮긴다

* heading, 섹션 밑 공간 설정 로직을 PdfTypesetter로 옮긴다

* 로직 일반화한다
  - 이제 ResumePrinter의 조판 로직이 PdfTypesetter로 분리되었고, 모두
    같은 형식으로 호출하므로 반복자 하나로 묶을 수 있다
  - 하지만 이력서의 섹션은 정해진 순서를 따라야 하기 때문에 순서를
    명시해주는 코드를 추가한다
  - DocumentWriter#read_sections()에서 섹션 텍스트를 읽어올 때, 읽어올
    파일명을 명시하지 않아도 되도록 바꾼다.
