### PR TITLE
헤딩 제목 포맷팅, 폰트 사이즈 검색 연산의 책임을 적절한 객체로 옮긴다

### DIFF
--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -33,7 +33,6 @@ class ResumePrinter
         :doc_writer => @doc_writer,
         :doc => doc,
         :formatting_config => @formatting_config,
-        :font_manager => @font_manager,
         :layout_arranger => @layout_arranger,
         :parser => @parser
       }

--- a/lib/mk_resume/document_writer.rb
+++ b/lib/mk_resume/document_writer.rb
@@ -19,14 +19,24 @@ module MkResume
       File.read(File.join(File.dirname(__FILE__), *relative_path, *%W[#{file_nm}]))
     end
 
-    def write_heading(pdf_doc, txt, options = {})
+    def write_heading(pdf_doc, heading_sym, options = {})
       h_rule(pdf_doc)
       line_spacing(pdf_doc, 9.5)
       write_text(
         pdf_doc,
-        txt,
+        capitalize(heading_sym),
         options
       )
+    end
+
+    def capitalize(section_title_sym)
+      section_title = section_title_sym.to_s
+
+      if section_title.match?(/.*_.*/) == false
+        section_title.capitalize
+      end
+
+      section_title.split("_").map(&:capitalize).join(" ")
     end
 
     def draw_horizontal_rule(pdf_doc)

--- a/lib/mk_resume/font_manager.rb
+++ b/lib/mk_resume/font_manager.rb
@@ -1,7 +1,5 @@
 module MkResume
   class FontManager
-    FONT_SIZE = {:name => 11, :channel => 10, :heading => 9.5, :body => 9.5}
-
     def load_font(pdf_doc)
       Prawn::Font::AFM.hide_m17n_warning = true
       pdf_doc.font_families.update(
@@ -11,10 +9,6 @@ module MkResume
         }
       )
       pdf_doc.font "NotoSans"
-    end
-
-    def find_font_size usage
-      FONT_SIZE[usage]
     end
   end
 end

--- a/lib/mk_resume/formatting_config.rb
+++ b/lib/mk_resume/formatting_config.rb
@@ -1,27 +1,33 @@
 module MkResume
   class FormattingConfig
-    def personal_info line_no, font_manager
+    FONT_SIZE = {:name => 11, :channel => 10, :heading => 9.5, :body => 9.5}
+
+    def find_font_size usage
+      FONT_SIZE[usage]
+    end
+
+    def personal_info line_no
       formatting_config = [
         {
-          size: font_manager.find_font_size(:name),
+          size: find_font_size(:name),
           style: :bold,
           leading: 8
         },
         {
-          size: font_manager.find_font_size(:channel),
+          size: find_font_size(:channel),
           leading: 5
         },
         {
-          size: font_manager.find_font_size(:channel),
+          size: find_font_size(:channel),
           leading: 5
         },
         {
-          size: font_manager.find_font_size(:channel),
+          size: find_font_size(:channel),
           leading: 5,
           inline_format: true
         },
         {
-          size: font_manager.find_font_size(:channel),
+          size: find_font_size(:channel),
           leading: 5,
           inline_format: true
         }
@@ -29,17 +35,17 @@ module MkResume
       formatting_config[line_no]
     end
 
-    def introduction usage, font_manager
+    def introduction usage
       line_height = 1.45
 
       formatting_config = {
         :heading => {
-          size: font_manager.find_font_size(:heading),
+          size: find_font_size(:heading),
           style: :bold,
-          leading: line_height * font_manager.find_font_size(:heading)
+          leading: line_height * find_font_size(:heading)
         },
         :default => {
-          size: font_manager.find_font_size(:body),
+          size: find_font_size(:body),
           leading: 6,
           indent_paragraphs: 0
         }
@@ -48,22 +54,22 @@ module MkResume
       formatting_config[usage]
     end
 
-    def work_experience usage, font_manager
+    def work_experience usage
       line_height = 1.45
 
       formatting_config = {
         :heading => {
-          size: font_manager.find_font_size(:heading),
+          size: find_font_size(:heading),
           style: :bold,
-          leading: line_height * font_manager.find_font_size(:heading)
+          leading: line_height * find_font_size(:heading)
         },
         :default => {
-          size: font_manager.find_font_size(:body),
+          size: find_font_size(:body),
           leading: 6,
           indent_paragraphs: 0
         },
         :long_leading => {
-          size: font_manager.find_font_size(:body),
+          size: find_font_size(:body),
           leading: 12,
           indent_paragraphs: 0
         }
@@ -72,21 +78,21 @@ module MkResume
       formatting_config[usage]
     end
 
-    def side_project usage, font_manager
+    def side_project usage
       line_height = 1.45
 
       formatting_config = {
         :heading => {
-          size: font_manager.find_font_size(:heading),
+          size: find_font_size(:heading),
           style: :bold,
-          leading: line_height * font_manager.find_font_size(:heading)
+          leading: line_height * find_font_size(:heading)
         },
         :project => {
-          size: font_manager.find_font_size(:body),
+          size: find_font_size(:body),
           indent_paragraphs: 0
         },
         :default => {
-          size: font_manager.find_font_size(:body),
+          size: find_font_size(:body),
           leading: 6,
           indent_paragraphs: 0
         }
@@ -95,21 +101,21 @@ module MkResume
       formatting_config[usage]
     end
 
-    def portfolio usage, font_manager
+    def portfolio usage
       line_height = 1.45
 
       formatting_config = {
         :heading => {
-          size: font_manager.find_font_size(:heading),
+          size: find_font_size(:heading),
           style: :bold,
-          leading: line_height * font_manager.find_font_size(:heading)
+          leading: line_height * find_font_size(:heading)
         },
         :project => {
-          size: font_manager.find_font_size(:body),
+          size: find_font_size(:body),
           indent_paragraphs: 0
         },
         :default => {
-          size: font_manager.find_font_size(:body),
+          size: find_font_size(:body),
           leading: 6,
           indent_paragraphs: 0
         }
@@ -118,25 +124,25 @@ module MkResume
       formatting_config[usage]
     end
 
-    def education usage, font_manager, doc
+    def education usage, doc
       line_height = 1.45
       left_col_width = 180 # Adjust based on content and page layout needs
       right_col_start = left_col_width + 10 # Spacing between columns
 
       formatting_config = {
         :heading => {
-          size: font_manager.find_font_size(:heading),
+          size: find_font_size(:heading),
           style: :bold,
-          leading: line_height * font_manager.find_font_size(:heading)
+          leading: line_height * find_font_size(:heading)
         },
         :left => {
-          size: font_manager.find_font_size(:body),
+          size: find_font_size(:body),
           at: [0, y_position(doc)],
           width: left_col_width,
           align: :left
         },
         :right => {
-          size: font_manager.find_font_size(:body),
+          size: find_font_size(:body),
           at: [right_col_start, y_position(doc)],
           width: bound_width(doc) - right_col_start,
           align: :left

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -61,7 +61,7 @@ module MkResume
         opts[:doc_writer].write_heading(
           opts[:doc],
           :side_project,
-          opts[:formatting_config].side_project(:heading, opts[:font_manager])
+          opts[:formatting_config].side_project(:heading)
         )
 
         side_projs = []
@@ -82,7 +82,7 @@ module MkResume
               { text: "#{link_text}", leading: 6, styles: [:underline], color: "888888", link: link_url },
               { text: ")" },
             ],
-            opts[:formatting_config].side_project(:project, opts[:font_manager])
+            opts[:formatting_config].side_project(:project)
           )
 
           opts[:layout_arranger].v_space(opts[:doc], 2)
@@ -91,7 +91,7 @@ module MkResume
             opts[:doc],
             "      ",
             side_proj[:proj_desc],
-            opts[:formatting_config].side_project(:default, opts[:font_manager])
+            opts[:formatting_config].side_project(:default)
           )
           opts[:layout_arranger].v_space(opts[:doc], 2)
           opts[:layout_arranger].v_space(opts[:doc], 2)
@@ -116,7 +116,7 @@ module MkResume
         opts[:doc_writer].write_heading(
           opts[:doc],
           :work_experience,
-          opts[:formatting_config].work_experience(:heading, opts[:font_manager])
+          opts[:formatting_config].work_experience(:heading)
         )
 
         work_exps = []
@@ -128,13 +128,13 @@ module MkResume
           opts[:doc_writer].write_text(
             opts[:doc],
             work_exp[:company_nm],
-            opts[:formatting_config].work_experience(:default, opts[:font_manager])
+            opts[:formatting_config].work_experience(:default)
                               .merge!({:line_spacing_pt => 2})
           )
           opts[:doc_writer].write_text(
             opts[:doc],
             "사용기술: #{work_exp[:skill_set]}",
-            opts[:formatting_config].work_experience(:long_leading, opts[:font_manager])
+            opts[:formatting_config].work_experience(:long_leading)
                               .merge!({:line_spacing_pt => 2})
           ) if work_exp[:skill_set]
 
@@ -142,7 +142,7 @@ module MkResume
             opts[:doc_writer].write_text(
               opts[:doc],
               task,
-              opts[:formatting_config].work_experience(:default, opts[:font_manager])
+              opts[:formatting_config].work_experience(:default)
             )
 
             work_exp[:project][task].each do |task_info|
@@ -151,7 +151,7 @@ module MkResume
                   opts[:doc],
                   "      ",
                   task_desc,
-                  opts[:formatting_config].work_experience(:default, opts[:font_manager])
+                  opts[:formatting_config].work_experience(:default)
                 ) if task_desc != :EMPTY_TASK_DESC
                 task_details = task_info[task_desc]
                 task_details.each do |task_detail|
@@ -159,7 +159,7 @@ module MkResume
                     opts[:doc],
                     "      ",
                     "- #{task_detail}",
-                    opts[:formatting_config].work_experience(:default, opts[:font_manager])
+                    opts[:formatting_config].work_experience(:default)
                                       .merge!({:line_spacing_pt => 2})
                   )
                 end
@@ -189,7 +189,7 @@ module MkResume
         opts[:doc_writer].write_heading(
           opts[:doc],
           :portfolio,
-          opts[:formatting_config].portfolio(:heading, opts[:font_manager])
+          opts[:formatting_config].portfolio(:heading)
         )
 
         portfolios = []
@@ -212,35 +212,35 @@ module MkResume
               { text: "#{link_text}", leading: 6, styles: [:underline], color: "888888", link: link_url },
               { text: ")" },
             ],
-            opts[:formatting_config].portfolio(:project, opts[:font_manager])
+            opts[:formatting_config].portfolio(:project)
           )
           opts[:layout_arranger].v_space(opts[:doc], 10)
 
           opts[:doc_writer].write_text(
             opts[:doc],
             portfolio[:desc],
-            opts[:formatting_config].portfolio(:default, opts[:font_manager])
+            opts[:formatting_config].portfolio(:default)
                                     .merge!({:line_spacing_pt => 2})
           )
 
           opts[:doc_writer].write_text(
             opts[:doc],
             "사용 기술: #{portfolio[:tech_stack]}",
-            opts[:formatting_config].portfolio(:default, opts[:font_manager])
+            opts[:formatting_config].portfolio(:default)
                                     .merge!({:line_spacing_pt => 2})
           )
 
           opts[:doc_writer].write_text(
             opts[:doc],
             "담당 작업",
-            opts[:formatting_config].portfolio(:default, opts[:font_manager])
+            opts[:formatting_config].portfolio(:default)
           )
           portfolio[:project][:tasks].each do |task|
             opts[:doc_writer].write_indented_text(
               opts[:doc],
               "  ",
               "- #{task}",
-              opts[:formatting_config].portfolio(:default, opts[:font_manager])
+              opts[:formatting_config].portfolio(:default)
                                       .merge!({:line_spacing_pt => 2})
             )
           end
@@ -251,7 +251,7 @@ module MkResume
               opts[:doc_writer].write_text(
                 opts[:doc],
                 "해결한 문제: #{trb_sht_desc}",
-                opts[:formatting_config].portfolio(:default, opts[:font_manager])
+                opts[:formatting_config].portfolio(:default)
               )
 
               trb_sht_info[trb_sht_desc].each do |trb_sht_detail|
@@ -259,7 +259,7 @@ module MkResume
                   opts[:doc],
                   "  ",
                   "- #{trb_sht_detail}",
-                  opts[:formatting_config].portfolio(:default, opts[:font_manager])
+                  opts[:formatting_config].portfolio(:default)
                                           .merge!({:line_spacing_pt => 2})
                 )
               end
@@ -294,7 +294,7 @@ module MkResume
         opts[:doc_writer].write_heading(
           opts[:doc],
           :introduction,
-          opts[:formatting_config].introduction(:heading, opts[:font_manager])
+          opts[:formatting_config].introduction(:heading)
         )
 
         section_txt.split("\n").each do |txt|
@@ -302,7 +302,7 @@ module MkResume
             opts[:doc],
             "- ",
             txt,
-            opts[:formatting_config].introduction(:default, opts[:font_manager])
+            opts[:formatting_config].introduction(:default)
                               .merge!({:line_spacing_pt => 2})
           )
         end
@@ -325,7 +325,7 @@ module MkResume
         opts[:doc_writer].write_heading(
           opts[:doc],
           :education,
-          opts[:formatting_config].education(:heading, opts[:font_manager], opts[:doc])
+          opts[:formatting_config].education(:heading, opts[:doc])
         )
 
         section_txt.split("\n")
@@ -336,13 +336,13 @@ module MkResume
           opts[:doc_writer].write_text_box(
             opts[:doc],
             left_text,
-            opts[:formatting_config].education(:left, opts[:font_manager], opts[:doc])
+            opts[:formatting_config].education(:left, opts[:doc])
           )
 
           opts[:doc_writer].write_text_box(
             opts[:doc],
             right_text,
-            opts[:formatting_config].education(:right, opts[:font_manager], opts[:doc])
+            opts[:formatting_config].education(:right, opts[:doc])
           )
 
           opts[:layout_arranger].v_space(opts[:doc], 15)
@@ -364,7 +364,7 @@ module MkResume
           opts[:doc_writer].write_text(
             opts[:doc],
             text,
-            opts[:formatting_config].personal_info(idx, opts[:font_manager])
+            opts[:formatting_config].personal_info(idx)
           )
         end
         opts[:layout_arranger].v_space(opts[:doc], 14.5)

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -60,7 +60,7 @@ module MkResume
       lambda {|section_txt, opts|
         opts[:doc_writer].write_heading(
           opts[:doc],
-          :side_project.to_s.split("_").map(&:capitalize).join(" "),
+          :side_project,
           opts[:formatting_config].side_project(:heading, opts[:font_manager])
         )
 
@@ -115,7 +115,7 @@ module MkResume
       lambda {|section_txt, opts|
         opts[:doc_writer].write_heading(
           opts[:doc],
-          :work_experience.to_s.split("_").map(&:capitalize).join(" "),
+          :work_experience,
           opts[:formatting_config].work_experience(:heading, opts[:font_manager])
         )
 
@@ -188,7 +188,7 @@ module MkResume
       lambda {|section_txt, opts|
         opts[:doc_writer].write_heading(
           opts[:doc],
-          :portfolio.to_s.capitalize,
+          :portfolio,
           opts[:formatting_config].portfolio(:heading, opts[:font_manager])
         )
 
@@ -293,7 +293,7 @@ module MkResume
       lambda {|section_txt, opts|
         opts[:doc_writer].write_heading(
           opts[:doc],
-          :introduction.to_s.capitalize,
+          :introduction,
           opts[:formatting_config].introduction(:heading, opts[:font_manager])
         )
 
@@ -324,7 +324,7 @@ module MkResume
       lambda {|section_txt, opts|
         opts[:doc_writer].write_heading(
           opts[:doc],
-          :education.to_s.capitalize,
+          :education,
           opts[:formatting_config].education(:heading, opts[:font_manager], opts[:doc])
         )
 

--- a/spec/mk_resume/document_writer_spec.rb
+++ b/spec/mk_resume/document_writer_spec.rb
@@ -11,5 +11,17 @@ describe MkResume::DocumentWriter do
     dw.read_sections(%W[.. .. spec  data src])
     expect(dw.sections.keys.size).not_to be(0)
   end
+
+  context "헤딩 생성 시 자동으로 포맷팅한다" do
+    dw = MkResume::DocumentWriter.new
+
+    it "_로 구분되지 않은 경우 헤딩용 제목을 섹션 파일명으로부터 만들 수 있다" do
+      expect(dw.capitalize(:portfolio)).to eq("Portfolio")
+    end
+
+    it "_로 구분된 경우 헤딩용 제목을 섹션 파일명으로부터 만들 수 있다" do
+      expect(dw.capitalize(:side_project)).to eq("Side Project")
+    end
+  end
 end
 


### PR DESCRIPTION
- 헤딩 타이틀 포맷팅을 조판 전략 객체 각각에서 하지 않고, DocumentWriter 객체에서 해주도록 한다
- FormattingConfig에서만 폰트 사이즈 정보를 쓴다. FormattingConfig로 옮겨서
FormattingConfig의 FontManager에 대한 의존성을 제거한다