### PR TITLE
포맷 정보를 동적으로 가져올 수 있다

### DIFF
--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -18,7 +18,10 @@ class ResumePrinter
     @parser = MkResume::SectionParser.new
   end
 
-  def print(relative_path)
+  def print(relative_path, section_order = [
+      :personal_info, :introduction, :portfolio,
+      :work_experience, :side_project, :education
+    ])
 
     Prawn::Document.generate(
       "output.pdf",
@@ -38,10 +41,7 @@ class ResumePrinter
       }
 
       sections = @doc_writer.read_sections(relative_path)
-      [
-        :personal_info, :introduction, :portfolio,
-        :work_experience, :side_project, :education
-      ].each { |section_nm|
+      section_order.each { |section_nm|
         typesetter.handler(sections[section_nm]).call(
           section_nm,
           sections[section_nm],

--- a/lib/mk_resume.rb
+++ b/lib/mk_resume.rb
@@ -43,6 +43,7 @@ class ResumePrinter
         :work_experience, :side_project, :education
       ].each { |section_nm|
         typesetter.handler(sections[section_nm]).call(
+          section_nm,
           sections[section_nm],
           typeset_opts
         )

--- a/lib/mk_resume/formatting_config.rb
+++ b/lib/mk_resume/formatting_config.rb
@@ -152,6 +152,13 @@ module MkResume
       formatting_config[usage]
     end
 
+    def method_missing(symbol, *args)
+      raise FormattingConfigNotExistsError.new(
+        "Formatting config for '#{symbol.to_s}' doesn't exist.
+You may have forgot to add config for newly added section"
+      )
+    end
+
     def width_of_bounding_box(pdf_doc)
       pdf_doc.bounds.width
     end
@@ -164,4 +171,6 @@ module MkResume
 
     alias_method :y_position, :y_position_of_bounding_box
   end
+
+  class FormattingConfigNotExistsError < StandardError; end
 end

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -57,11 +57,11 @@ module MkResume
     end
 
     def handler
-      lambda {|section_txt, opts|
+      lambda {|section_nm, section_txt, opts|
         opts[:doc_writer].write_heading(
           opts[:doc],
           :side_project,
-          opts[:formatting_config].side_project(:heading)
+          opts[:formatting_config].send(section_nm, :heading)
         )
 
         side_projs = []
@@ -82,7 +82,7 @@ module MkResume
               { text: "#{link_text}", leading: 6, styles: [:underline], color: "888888", link: link_url },
               { text: ")" },
             ],
-            opts[:formatting_config].side_project(:project)
+            opts[:formatting_config].send(section_nm, :project)
           )
 
           opts[:layout_arranger].v_space(opts[:doc], 2)
@@ -91,7 +91,7 @@ module MkResume
             opts[:doc],
             "      ",
             side_proj[:proj_desc],
-            opts[:formatting_config].side_project(:default)
+            opts[:formatting_config].send(section_nm, :default)
           )
           opts[:layout_arranger].v_space(opts[:doc], 2)
           opts[:layout_arranger].v_space(opts[:doc], 2)
@@ -112,11 +112,11 @@ module MkResume
     end
 
     def handler
-      lambda {|section_txt, opts|
+      lambda {|section_nm, section_txt, opts|
         opts[:doc_writer].write_heading(
           opts[:doc],
           :work_experience,
-          opts[:formatting_config].work_experience(:heading)
+          opts[:formatting_config].send(section_nm, :heading)
         )
 
         work_exps = []
@@ -128,13 +128,13 @@ module MkResume
           opts[:doc_writer].write_text(
             opts[:doc],
             work_exp[:company_nm],
-            opts[:formatting_config].work_experience(:default)
+            opts[:formatting_config].send(section_nm, :default)
                               .merge!({:line_spacing_pt => 2})
           )
           opts[:doc_writer].write_text(
             opts[:doc],
             "사용기술: #{work_exp[:skill_set]}",
-            opts[:formatting_config].work_experience(:long_leading)
+            opts[:formatting_config].send(section_nm, :long_leading)
                               .merge!({:line_spacing_pt => 2})
           ) if work_exp[:skill_set]
 
@@ -142,7 +142,7 @@ module MkResume
             opts[:doc_writer].write_text(
               opts[:doc],
               task,
-              opts[:formatting_config].work_experience(:default)
+              opts[:formatting_config].send(section_nm, :default)
             )
 
             work_exp[:project][task].each do |task_info|
@@ -151,7 +151,7 @@ module MkResume
                   opts[:doc],
                   "      ",
                   task_desc,
-                  opts[:formatting_config].work_experience(:default)
+                  opts[:formatting_config].send(section_nm, :default)
                 ) if task_desc != :EMPTY_TASK_DESC
                 task_details = task_info[task_desc]
                 task_details.each do |task_detail|
@@ -159,7 +159,7 @@ module MkResume
                     opts[:doc],
                     "      ",
                     "- #{task_detail}",
-                    opts[:formatting_config].work_experience(:default)
+                    opts[:formatting_config].send(section_nm, :default)
                                       .merge!({:line_spacing_pt => 2})
                   )
                 end
@@ -185,11 +185,11 @@ module MkResume
     end
 
     def handler
-      lambda {|section_txt, opts|
+      lambda {|section_nm, section_txt, opts|
         opts[:doc_writer].write_heading(
           opts[:doc],
           :portfolio,
-          opts[:formatting_config].portfolio(:heading)
+          opts[:formatting_config].send(section_nm, :heading)
         )
 
         portfolios = []
@@ -212,35 +212,35 @@ module MkResume
               { text: "#{link_text}", leading: 6, styles: [:underline], color: "888888", link: link_url },
               { text: ")" },
             ],
-            opts[:formatting_config].portfolio(:project)
+            opts[:formatting_config].send(section_nm, :project)
           )
           opts[:layout_arranger].v_space(opts[:doc], 10)
 
           opts[:doc_writer].write_text(
             opts[:doc],
             portfolio[:desc],
-            opts[:formatting_config].portfolio(:default)
+            opts[:formatting_config].send(section_nm, :default)
                                     .merge!({:line_spacing_pt => 2})
           )
 
           opts[:doc_writer].write_text(
             opts[:doc],
             "사용 기술: #{portfolio[:tech_stack]}",
-            opts[:formatting_config].portfolio(:default)
+            opts[:formatting_config].send(section_nm, :default)
                                     .merge!({:line_spacing_pt => 2})
           )
 
           opts[:doc_writer].write_text(
             opts[:doc],
             "담당 작업",
-            opts[:formatting_config].portfolio(:default)
+            opts[:formatting_config].send(section_nm, :default)
           )
           portfolio[:project][:tasks].each do |task|
             opts[:doc_writer].write_indented_text(
               opts[:doc],
               "  ",
               "- #{task}",
-              opts[:formatting_config].portfolio(:default)
+              opts[:formatting_config].send(section_nm, :default)
                                       .merge!({:line_spacing_pt => 2})
             )
           end
@@ -251,7 +251,7 @@ module MkResume
               opts[:doc_writer].write_text(
                 opts[:doc],
                 "해결한 문제: #{trb_sht_desc}",
-                opts[:formatting_config].portfolio(:default)
+                opts[:formatting_config].send(section_nm, :default)
               )
 
               trb_sht_info[trb_sht_desc].each do |trb_sht_detail|
@@ -259,7 +259,7 @@ module MkResume
                   opts[:doc],
                   "  ",
                   "- #{trb_sht_detail}",
-                  opts[:formatting_config].portfolio(:default)
+                  opts[:formatting_config].send(section_nm, :default)
                                           .merge!({:line_spacing_pt => 2})
                 )
               end
@@ -290,11 +290,11 @@ module MkResume
     end
 
     def handler
-      lambda {|section_txt, opts|
+      lambda {|section_nm, section_txt, opts|
         opts[:doc_writer].write_heading(
           opts[:doc],
           :introduction,
-          opts[:formatting_config].introduction(:heading)
+          opts[:formatting_config].send(section_nm, :heading)
         )
 
         section_txt.split("\n").each do |txt|
@@ -302,7 +302,7 @@ module MkResume
             opts[:doc],
             "- ",
             txt,
-            opts[:formatting_config].introduction(:default)
+            opts[:formatting_config].send(section_nm, :default)
                               .merge!({:line_spacing_pt => 2})
           )
         end
@@ -321,11 +321,11 @@ module MkResume
     end
 
     def handler
-      lambda {|section_txt, opts|
+      lambda {|section_nm, section_txt, opts|
         opts[:doc_writer].write_heading(
           opts[:doc],
           :education,
-          opts[:formatting_config].education(:heading, opts[:doc])
+          opts[:formatting_config].send(section_nm, :heading, opts[:doc])
         )
 
         section_txt.split("\n")
@@ -336,13 +336,13 @@ module MkResume
           opts[:doc_writer].write_text_box(
             opts[:doc],
             left_text,
-            opts[:formatting_config].education(:left, opts[:doc])
+            opts[:formatting_config].send(section_nm, :left, opts[:doc])
           )
 
           opts[:doc_writer].write_text_box(
             opts[:doc],
             right_text,
-            opts[:formatting_config].education(:right, opts[:doc])
+            opts[:formatting_config].send(section_nm, :right, opts[:doc])
           )
 
           opts[:layout_arranger].v_space(opts[:doc], 15)
@@ -359,12 +359,12 @@ module MkResume
     end
 
     def handler
-      lambda {|section_txt, opts|
+      lambda {|section_nm, section_txt, opts|
         section_txt.split("\n")[0..4].each.with_index do |text, idx|
           opts[:doc_writer].write_text(
             opts[:doc],
             text,
-            opts[:formatting_config].personal_info(idx)
+            opts[:formatting_config].send(section_nm, idx)
           )
         end
         opts[:layout_arranger].v_space(opts[:doc], 14.5)

--- a/spec/acceptance_spec.rb
+++ b/spec/acceptance_spec.rb
@@ -1,0 +1,24 @@
+require_relative "../lib/mk_resume"
+
+describe ResumePrinter do
+  RSpec.configure do |config|
+    config.filter_run_when_matching(focus: true)
+    config.example_status_persistence_file_path = 'spec/pass_fail_history'
+  end
+
+  it "포맷 정보를 불러올 메서드명을 동적으로 결정할 수 있다" do
+    unconfigured_section = :list_section
+    resume_printer = ResumePrinter.new
+    expect {
+      resume_printer.print(%W[.. .. spec data src],
+        [
+          unconfigured_section, :introduction, :portfolio,
+          :work_experience, :side_project, :education
+        ]
+      )
+    }.to raise_error(
+      MkResume::FormattingConfigNotExistsError,
+      /#{unconfigured_section.to_s}/
+    )
+  end
+end


### PR DESCRIPTION
* 포맷 정보를 동적으로 가져올 수 있도록 바꾼다
  - Kernel#send()를 써서 섹션 파일명이 바뀌더라도 PdfTypesetter의 전략에 정의한 handler 메서드 정의를
  수정할 필요 없도록 고친다

* 포맷 정보를 동적으로 가져올 수 있음을 테스트한다
  - 포맷 정보를 정의하지 않은 섹션을 프린트하려고 할 때, 해당 섹션명으로 FormattingConfig에 메시지를 보내는지 확인한다.
  이를 위해 ResumePrinter에 section_order를 추가해서 기존에 정의한 섹션 이외의 섹션을 ResumePrinter에 명시할 수
  있도록 바꾼다
  - 이런 상황(새로운 섹션을 프린트하려고 하지만 포맷 정보가 정의되어 있지 않은 경우)이 발생했음을 알 수 있도록
  method_missing 훅을 재정의한다