### PR TITLE
DocumentWriter#write_text에서 링크가 포함된 텍스트를 처리할 수 있다

### DIFF
--- a/lib/mk_resume/document_writer.rb
+++ b/lib/mk_resume/document_writer.rb
@@ -80,7 +80,13 @@ module MkResume
         pdf_doc.text(txt, options)
       end
       if txt_type[:text_link_combined]
+        wrapped_txt = wrap_link_n_txt txt
 
+        write_formatted_text(
+          pdf_doc,
+          wrapped_txt,
+          options
+        )
       end
 
       if options[:line_spacing_pt] == nil
@@ -99,6 +105,16 @@ module MkResume
       link_regex = /<link href='([^']*)'>([^<]*)<\/link>/
 
       text.match(link_regex) ? link_style % text : text
+    end
+
+    def wrap_link_n_txt txt
+      captures = txt.match(/^(.*)<link href='([^']*)'>([^<]*)<\/link>(.*)$/).captures
+      [
+        { text: captures[0].strip!, leading: 6 },
+        { text: " (" },
+        { text: captures[2], leading: 6, styles: [:underline], color: "888888", link: captures[1] },
+        { text: ")" }
+      ]
     end
 
     def indent(pdf_doc, left_width, &text_writer)

--- a/lib/mk_resume/document_writer.rb
+++ b/lib/mk_resume/document_writer.rb
@@ -71,8 +71,17 @@ module MkResume
     end
 
     def write_text(pdf_doc, txt, options = {})
-      txt = wrap_link(txt)
-      pdf_doc.text(txt, options)
+      txt_type = find_txt_type(txt)
+      if txt_type[:simple_text]
+        pdf_doc.text(txt, options)
+      end
+      if txt_type[:only_link]
+        txt = wrap_link(txt)
+        pdf_doc.text(txt, options)
+      end
+      if txt_type[:text_link_combined]
+
+      end
 
       if options[:line_spacing_pt] == nil
         line_spacing(pdf_doc, 0)

--- a/lib/mk_resume/document_writer.rb
+++ b/lib/mk_resume/document_writer.rb
@@ -51,6 +51,25 @@ module MkResume
       end
     end
 
+    def find_txt_type(text)
+      txt_type = {
+        :simple_text => false,
+        :only_link => false,
+        :text_link_combined => false
+      }
+      link_regex = /<link href='([^']*)'>([^<]*)<\/link>/
+      text_match = text.match(link_regex)
+
+      if text_match.nil?
+        txt_type[:simple_text] = true
+        return txt_type
+      end
+
+      txt_type[:only_link] = true if text_match[0] == text
+      txt_type[:text_link_combined] = true if text_match[0] != text
+      txt_type
+    end
+
     def write_text(pdf_doc, txt, options = {})
       txt = wrap_link(txt)
       pdf_doc.text(txt, options)

--- a/lib/mk_resume/pdf_typesetter.rb
+++ b/lib/mk_resume/pdf_typesetter.rb
@@ -200,18 +200,9 @@ module MkResume
         end
 
         portfolios.each do |portfolio|
-          match = portfolio[:repo_link].match(/<link href='([^']*)'>([^<]*)<\/link>/)
-          link_url = match[1]
-          link_text = match[2]
-
-          opts[:doc_writer].write_formatted_text(
+          opts[:doc_writer].write_text(
             opts[:doc],
-            [
-              { text: portfolio[:portfolio_nm], leading: 6 },
-              { text: " (" },
-              { text: "#{link_text}", leading: 6, styles: [:underline], color: "888888", link: link_url },
-              { text: ")" },
-            ],
+            portfolio[:portfolio_nm],
             opts[:formatting_config].send(section_nm, :project)
           )
           opts[:layout_arranger].v_space(opts[:doc], 10)

--- a/spec/data/src/portfolio
+++ b/spec/data/src/portfolio
@@ -1,6 +1,5 @@
-portfolio_nm: Weddy
+portfolio_nm: Weddy <link href='https://github.com/your-weddy/back/'>프로젝트 링크</link>
 desc: 결혼 준비를 도와주는 웹 서비스의 백엔드 서버
-repo_link: <link href='https://github.com/your-weddy/back/'>프로젝트 링크</link>
 service_link: https://weddy-smoky.vercel.app/
 swagger_link: https://your-weddy.pe.kr/swagger-ui/index.html
 tech_stack: EC2, S3, Java, Spring Boot, MyBatis, MySql, Gradle, Mockito, JUnit
@@ -20,9 +19,8 @@ project:
   작업하면서 다른 리소스의 서비스 로직이 필요할 경우, 미리 정의한 인터페이스를 기준으로 작업
   작업을 합치기 전까지 해당 서비스 로직의 반환값은 픽스쳐 데이터로 대신함
 
-portfolio_nm: Freesize
+portfolio_nm: Freesize <link href='https://github.com/rogarithm/freesize'>프로젝트 링크</link>
 desc: LoRA 학습에 사용하기 위한 이미지 전처리를 제공하는 웹 서비스의 백엔드 서버
-repo_link: <link href='https://github.com/rogarithm/freesize'>프로젝트 링크</link>
 service_link: https://freesize.vercel.app/
 tech_stack: EC2, S3, Java, Spring Boot, WebClient, Gradle, JUnit
 project:

--- a/spec/mk_resume/document_writer_spec.rb
+++ b/spec/mk_resume/document_writer_spec.rb
@@ -71,7 +71,7 @@ describe MkResume::DocumentWriter do
       link_n_txt = "blah <link href='url'>url_txt</link>"
       expect(dw.wrap_link_n_txt link_n_txt)
         .to eq([
-                 { text: "blah ", leading: 6 },
+                 { text: "blah", leading: 6 },
                  { text: " (" },
                  { text: "url_txt", leading: 6, styles: [:underline], color: "888888", link: "url" },
                  { text: ")" }

--- a/spec/mk_resume/document_writer_spec.rb
+++ b/spec/mk_resume/document_writer_spec.rb
@@ -43,5 +43,48 @@ describe MkResume::DocumentWriter do
       expect(txt_type_3[:text_link_combined]).to eq(true)
     end
   end
+
+  context "링크 텍스트 포함 여부에 따라 링크를 자동으로 포맷팅한다" do
+    it "링크 텍스트가 없을 경우 text를 따로 포맷팅하지 않고, prawn#text를 호출한다" do
+      dw = MkResume::DocumentWriter.new
+      fake_doc = FakePrawn.new
+
+      dw.write_text(fake_doc, "sample text")
+      expect(fake_doc.txt_args).to eq(["sample text"])
+      expect(fake_doc.method_calls[:text]).to eq(1)
+      fake_doc.clear
+    end
+
+    it "링크 텍스트만 있을 경우 wrap_link를 호출해서 text를 link 형식으로 포맷팅하고, prawn#text를 호출한다" do
+      dw = MkResume::DocumentWriter.new
+      fake_doc = FakePrawn.new
+
+      link_txt = "<link href='url'>url_txt</link>"
+      dw.write_text(fake_doc, link_txt)
+      expect(fake_doc.txt_args).to eq([dw.wrap_link(link_txt)])
+      expect(fake_doc.method_calls[:text]).to eq(1)
+      fake_doc.clear
+    end
+  end
+
+  class FakePrawn
+    attr_reader :txt_args, :method_calls
+
+    def initialize
+      @txt_args = []
+      @method_calls = Hash.new(0)
+    end
+
+    def stroke_horizontal_rule; end
+    def move_down point; end
+    def text(txt, options)
+      @txt_args << txt
+      @method_calls[:text] = @method_calls[:text] + 1
+    end
+    def clear
+      @txt_args.clear
+      @method_calls.clear
+    end
+  end
 end
 

--- a/spec/mk_resume/document_writer_spec.rb
+++ b/spec/mk_resume/document_writer_spec.rb
@@ -23,5 +23,25 @@ describe MkResume::DocumentWriter do
       expect(dw.capitalize(:side_project)).to eq("Side Project")
     end
   end
+
+  context "텍스트 형식이 어떤지 판단할 수 있다" do
+    it "링크 텍스트가 없는 경우" do
+      dw = MkResume::DocumentWriter.new
+      txt_type_1 = dw.find_txt_type "sample text"
+      expect(txt_type_1[:simple_text]).to eq(true)
+    end
+
+    it "링크 텍스트만 있는 경우" do
+      dw = MkResume::DocumentWriter.new
+      txt_type_2 = dw.find_txt_type "<link href='url'>url_txt</link>"
+      expect(txt_type_2[:only_link]).to eq(true)
+    end
+
+    it "링크 텍스트와 일반 텍스트 둘 다 있는 경우" do
+      dw = MkResume::DocumentWriter.new
+      txt_type_3 = dw.find_txt_type "blah <link href='url'>url_txt</link> clah"
+      expect(txt_type_3[:text_link_combined]).to eq(true)
+    end
+  end
 end
 

--- a/spec/mk_resume/document_writer_spec.rb
+++ b/spec/mk_resume/document_writer_spec.rb
@@ -65,6 +65,29 @@ describe MkResume::DocumentWriter do
       expect(fake_doc.method_calls[:text]).to eq(1)
       fake_doc.clear
     end
+
+    it "링크 텍스트와 일반 텍스트가 모두 있을 경우 링크 형식과 그렇지 않은 형식을 따로 구분한다" do
+      dw = MkResume::DocumentWriter.new
+      link_n_txt = "blah <link href='url'>url_txt</link>"
+      expect(dw.wrap_link_n_txt link_n_txt)
+        .to eq([
+                 { text: "blah ", leading: 6 },
+                 { text: " (" },
+                 { text: "url_txt", leading: 6, styles: [:underline], color: "888888", link: "url" },
+                 { text: ")" }
+               ])
+    end
+
+    it "링크 텍스트와 일반 텍스트가 모두 있을 경우 write_formatted_text를 호출한다" do
+      dw = MkResume::DocumentWriter.new
+      fake_doc = FakePrawn.new
+
+      link_n_txt = "blah <link href='url'>url_txt</link>"
+      dw.write_text(fake_doc, link_n_txt)
+      expect(fake_doc.txt_args).to eq([dw.wrap_link_n_txt(link_n_txt)])
+      expect(fake_doc.method_calls[:formatted_text]).to eq(1)
+      fake_doc.clear
+    end
   end
 
   class FakePrawn
@@ -80,6 +103,10 @@ describe MkResume::DocumentWriter do
     def text(txt, options)
       @txt_args << txt
       @method_calls[:text] = @method_calls[:text] + 1
+    end
+    def formatted_text(txts, options)
+      @txt_args << txts
+      @method_calls[:formatted_text] = @method_calls[:formatted_text] + 1
     end
     def clear
       @txt_args.clear


### PR DESCRIPTION
#### 작업 설명
기존에는 링크가 포함되지 않은 텍스트, 링크만 갖고 있는 텍스트, 두 종류 모두를 갖는 텍스트
세 종류의 조판 로직을 각각 따로 구현하고 있다.
따로 구현하는 대신, 스크립트에서 텍스트 형식을 확인해서 각 형식마다 적절한 조판 로직을
알아서 적용할 수 있도록 하기 위해 다음과 같이 수정한다

* DocumentWriter#find_txt_type은 텍스트 형식을 구분할 수 있다
  - 위 세 가지 텍스트 형식을 구분한다

* DocumentWriter#write_text에서 세 가지 텍스트 형식을 처리할 수 있도록 바꾼다
  - 바로 링크 텍스트를 변환하는 대신, 먼저 텍스트 형식을 확인 후 필요한
    연산을 실행하도록 바꾼다
  - 기존에 처리하지 않던 텍스트 형식(링크 없는 텍스트+링크 텍스트)을 처리할 수 있다

* portfolio 섹션의 링크 텍스트를 DocumentWriter#write_text가 처리할 수 있도록 바꾼다